### PR TITLE
Defer named style registration until materialize (NamedStyleDescriptor parity)

### DIFF
--- a/fastpyxl/styles/styleable.py
+++ b/fastpyxl/styles/styleable.py
@@ -99,24 +99,50 @@ class NamedStyleDescriptor:
     def __set__(self, instance, value):
         if not getattr(instance, "_style"):
             instance._style = StyleArray()
-        coll = getattr(instance.parent.parent, self.collection)
+        wb = instance.parent.parent
+        coll = getattr(wb, self.collection)
+        pending_styles = getattr(instance, "_pending_styles", None)
+        if pending_styles is not None:
+            if isinstance(value, NamedStyle):
+                if value in coll:
+                    style = value
+                    instance._style = copy(style.as_tuple())
+                    instance._pending_named_style = None
+                    return
+                instance._pending_named_style = value
+                return
+            if value not in coll.names:
+                if value in styles:
+                    instance._pending_named_style = value
+                    return
+                raise ValueError("{0} is not a known style".format(value))
+            instance._pending_named_style = value
+            return
         if isinstance(value, NamedStyle):
             style = value
             if style not in coll:
-                instance.parent.parent.add_named_style(style)
+                wb.add_named_style(style)
         elif value not in coll.names:
             if value in styles: # is it builtin?
                 style = styles[value]
                 if style not in coll:
-                    instance.parent.parent.add_named_style(style)
+                    wb.add_named_style(style)
             else:
                 raise ValueError("{0} is not a known style".format(value))
         else:
             style = coll[value]
         instance._style = copy(style.as_tuple())
+        instance._pending_named_style = None
 
 
     def __get__(self, instance, cls):
+        if instance is None:
+            return self
+        pending = getattr(instance, "_pending_named_style", None)
+        if pending is not None:
+            if isinstance(pending, NamedStyle):
+                return pending.name
+            return pending
         if not getattr(instance, "_style"):
             instance._style = StyleArray()
         idx = getattr(instance._style, self.key)
@@ -156,7 +182,7 @@ class StyleableObject:
     quotePrefix = StyleArrayDescriptor('quotePrefix')
     pivotButton = StyleArrayDescriptor('pivotButton')
 
-    __slots__ = ('parent', '_style', '_pending_styles')
+    __slots__ = ('parent', '_style', '_pending_styles', '_pending_named_style')
 
     def __init__(self, sheet, style_array=None):
         self.parent = sheet
@@ -164,10 +190,38 @@ class StyleableObject:
             style_array = StyleArray(style_array)
         self._style = style_array
         self._pending_styles = {}
+        self._pending_named_style = None
 
     def _ensure_style_array(self):
         if self._style is None:
             self._style = StyleArray()
+
+    def _apply_pending_named_style(self):
+        pending = getattr(self, "_pending_named_style", None)
+        if pending is None:
+            return
+        wb = self.parent.parent
+        coll = wb._named_styles
+        if isinstance(pending, NamedStyle):
+            if pending.name in coll.names:
+                style = coll[pending.name]
+            else:
+                wb.add_named_style(pending)
+                style = pending
+        elif pending in coll.names:
+            style = coll[pending]
+        elif pending in styles:
+            st = styles[pending]
+            if st.name in coll.names:
+                style = coll[st.name]
+            else:
+                wb.add_named_style(st)
+                style = st
+        else:
+            raise ValueError("{0} is not a known style".format(pending))
+        self._style = copy(style.as_tuple())
+        self._pending_named_style = None
+
 
     def _apply_pending_styles(self):
         if not self._pending_styles:
@@ -190,12 +244,15 @@ class StyleableObject:
     @property
     def style_id(self):
         self._ensure_style_array()
+        self._apply_pending_named_style()
         self._apply_pending_styles()
         return self.parent.parent._cell_styles.add(self._style)
 
 
     @property
     def has_style(self):
+        if getattr(self, "_pending_named_style", None) is not None:
+            return True
         if self._pending_styles:
             return True
         if self._style is None:

--- a/fastpyxl/styles/tests/test_styleable.py
+++ b/fastpyxl/styles/tests/test_styleable.py
@@ -50,6 +50,11 @@ def Workbook():
             self._named_styles.append(style)
             style.bind(self)
 
+        def materialize_pending_style_components(self, styleable):
+            styleable._ensure_style_array()
+            styleable._apply_pending_named_style()
+            styleable._apply_pending_styles()
+
     return DummyWorkbook()
 
 
@@ -90,6 +95,50 @@ def test_style_descriptor_registration_deferred_until_style_id(StyleableObject):
 
     _ = so.style_id
     assert len(wb._fonts) == before + 1
+
+
+def test_named_style_registration_deferred_until_materialize(StyleableObject):
+    so = StyleableObject
+    wb = so.parent.parent
+    style = NamedStyle(name="Deferred")
+
+    before = len(wb._named_styles)
+    so.style = style
+    assert len(wb._named_styles) == before
+
+    wb.materialize_pending_style_components(so)
+    assert len(wb._named_styles) == before + 1
+    assert so.style == "Deferred"
+
+
+def test_named_style_readable_before_materialize(StyleableObject):
+    so = StyleableObject
+    wb = so.parent.parent
+    style = NamedStyle(name="Readable")
+
+    so.style = style
+    assert so.style == "Readable"
+    assert len(wb._named_styles) == 0
+
+
+def test_named_style_builtin_deferred_until_materialize(StyleableObject):
+    so = StyleableObject
+    wb = so.parent.parent
+    before = len(wb._named_styles)
+
+    so.style = "Hyperlink"
+    assert len(wb._named_styles) == before
+    assert so.style == "Hyperlink"
+
+    wb.materialize_pending_style_components(so)
+    assert len(wb._named_styles) == before + 1
+
+
+def test_has_style_true_when_named_style_pending(StyleableObject):
+    so = StyleableObject
+    so._style = None
+    so.style = "Hyperlink"
+    assert so.has_style
 
 
 class TestNamedStyle:
@@ -141,12 +190,14 @@ class TestNamedStyle:
 
     def test_copy_not_share(self, StyleableObject):
         s1 = StyleableObject
-        s1.parent.parent
+        wb = s1.parent.parent
 
         from copy import copy
         s2 = copy(s1)
         s1.style = "Hyperlink"
         s2.style = "Hyperlink"
+        wb.materialize_pending_style_components(s1)
+        wb.materialize_pending_style_components(s2)
         assert s1._style is not s2._style
 
 

--- a/fastpyxl/workbook/tests/test_workbook.py
+++ b/fastpyxl/workbook/tests/test_workbook.py
@@ -353,3 +353,16 @@ class TestStyleMaterialization:
         assert wb2.active["A1"].font.name == "Courier"
         assert wb2.active["A1"].font.size == 11
 
+    def test_named_style_registration_deferred_until_save(self, Workbook):
+        from fastpyxl.styles import NamedStyle
+
+        wb = Workbook()
+        cell = wb.active["A1"]
+        before = len(wb._named_styles)
+        cell.style = NamedStyle(name="SaveDeferred")
+        assert len(wb._named_styles) == before
+
+        buf = BytesIO()
+        wb.save(buf)
+        assert any(ns.name == "SaveDeferred" for ns in wb._named_styles)
+

--- a/fastpyxl/workbook/workbook.py
+++ b/fastpyxl/workbook/workbook.py
@@ -400,8 +400,8 @@ class Workbook:
         """Register shared style parts for *styleable* from deferred assignments.
 
         Styling attributes on cells and dimensions defer pushing fonts, fills,
-        borders, number formats, alignments, and protections into the workbook
-        until this method runs or until
+        borders, number formats, alignments, protections, and named styles
+        into the workbook until this method runs or until
         :attr:`~fastpyxl.styles.styleable.StyleableObject.style_id` is read.
 
         Saving a workbook calls this automatically for every standard worksheet,
@@ -410,6 +410,7 @@ class Workbook:
         written.
         """
         styleable._ensure_style_array()
+        styleable._apply_pending_named_style()
         styleable._apply_pending_styles()
 
 

--- a/fastpyxl/worksheet/copier.py
+++ b/fastpyxl/worksheet/copier.py
@@ -62,6 +62,10 @@ class WorksheetCopy:
                     td = target_cell._pending_styles
                 td.update(sp)
 
+            pn = getattr(source_cell, "_pending_named_style", None)
+            if pn is not None:
+                target_cell._pending_named_style = pn
+
             if source_cell.hyperlink:
                 target_cell._hyperlink = copy(source_cell.hyperlink)
 


### PR DESCRIPTION
## Summary
Aligns `cell.style = ...` with other deferred style attributes: assignment stores intent in `_pending_named_style`; `workbook.add_named_style` runs from `_apply_pending_named_style` during `materialize_pending_style_components`, save preparation, or when `style_id` is read (named tuple applied before granular `_pending_styles`).

## Changes
- `NamedStyleDescriptor`: defer when `_pending_styles` is present; immediate path unchanged when it is absent
- `StyleableObject`: new slot, `has_style` / `style_id` integration
- Worksheet copy copies `_pending_named_style`
- Tests for deferral, read-before-flush, save path, and copy

Closes #1

Made with [Cursor](https://cursor.com)