### PR TITLE
perf: eliminate getattr overhead via static typing

### DIFF
--- a/fastpyxl/cell/read_only.py
+++ b/fastpyxl/cell/read_only.py
@@ -20,10 +20,14 @@ class ReadOnlyCell:
 
 
     def __eq__(self, other):
-        for a in self.__slots__:
-            if getattr(self, a) != getattr(other, a):
-                return
-        return True
+        return (
+            self.parent == other.parent
+            and self.row == other.row
+            and self.column == other.column
+            and self._value == other._value
+            and self.data_type == other.data_type
+            and self._style_id == other._style_id
+        )
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/fastpyxl/chart/_chart.py
+++ b/fastpyxl/chart/_chart.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from operator import attrgetter
+from typing import Any
 
 from fastpyxl.compat import safe_string
 from fastpyxl.typed_serialisable.base import Serialisable
@@ -30,6 +31,9 @@ class ChartBase(Serialisable):
     """
 
     _plot_xml_tag: str | None = None
+    x_axis: Any = None
+    y_axis: Any = None
+    z_axis: Any = None
 
     display_blanks: str | None = Field.attribute(
         expected_type=str,
@@ -136,7 +140,7 @@ class ChartBase(Serialisable):
             if isinstance(own_tn, str):
                 resolved = own_tn
             elif cls is ChartBase:
-                pt = getattr(ChartBase, "_plot_xml_tag", None)
+                pt = ChartBase._plot_xml_tag
                 if pt:
                     resolved = pt
                 else:
@@ -184,9 +188,9 @@ class ChartBase(Serialisable):
 
     @property
     def _axes(self):
-        x = getattr(self, "x_axis", None)
-        y = getattr(self, "y_axis", None)
-        z = getattr(self, "z_axis", None)
+        x = self.x_axis
+        y = self.y_axis
+        z = self.z_axis
         return OrderedDict([(axis.axId, axis) for axis in (x, y, z) if axis])
 
     def set_categories(self, labels):

--- a/fastpyxl/chart/series.py
+++ b/fastpyxl/chart/series.py
@@ -251,7 +251,7 @@ class Series(Serialisable):
         self.extLst = extLst
 
     def _element_names_for_serialize(self):
-        order = getattr(self, "_serialize_element_order", None)
+        order = self._serialize_element_order
         if order is not None:
             return tuple(order)
         return super()._element_names_for_serialize()

--- a/fastpyxl/chartsheet/protection.py
+++ b/fastpyxl/chartsheet/protection.py
@@ -18,8 +18,12 @@ class ChartsheetProtection(Serialisable, _Protected):
     objects: bool | None = Field.attribute(expected_type=bool, allow_none=True, default=None)
 
     def __iter__(self):
-        for key in ("content", "objects", "password", "hashValue", "spinCount", "saltValue", "algorithmName"):
-            value = getattr(self, key, None)
+        for key, value in (
+            ("content", self.content), ("objects", self.objects),
+            ("password", self.password), ("hashValue", self.hashValue),
+            ("spinCount", self.spinCount), ("saltValue", self.saltValue),
+            ("algorithmName", self.algorithmName),
+        ):
             if value is not None:
                 yield key, str(int(value)) if isinstance(value, bool) else str(value)
 

--- a/fastpyxl/descriptors/__init__.py
+++ b/fastpyxl/descriptors/__init__.py
@@ -45,10 +45,10 @@ class MetaSerialisable(type):
         namespaced = []
         for k, v in methods.items():
             if isinstance(v, Descriptor):
-                ns = getattr(v, "namespace", None)
+                ns = v.namespace
                 if ns:
                     namespaced.append((k, "{%s}%s" % (ns, k)))
-                if getattr(v, "nested", False):
+                if v.nested:
                     nested.append(k)
                     elements.append(k)
                 elif isinstance(v, Sequence):

--- a/fastpyxl/descriptors/base.py
+++ b/fastpyxl/descriptors/base.py
@@ -14,6 +14,9 @@ from fastpyxl.utils.datetime import from_ISO8601
 
 
 class Descriptor:
+    namespace = None
+    nested = False
+
     def __init__(self, name=None, **kw):
         self.name = name
         for k, v in kw.items():

--- a/fastpyxl/descriptors/excel.py
+++ b/fastpyxl/descriptors/excel.py
@@ -15,7 +15,8 @@ from . import (
     String,
     Sequence,
 )
-from .serialisable import Serialisable
+from fastpyxl.typed_serialisable.base import Serialisable
+from fastpyxl.typed_serialisable.fields import Field
 
 
 class HexBinary(MatchPattern):
@@ -57,7 +58,9 @@ class Percentage(MinMax):
 
 class Extension(Serialisable):
 
-    uri = String()
+    tagname = "ext"
+
+    uri: str | None = Field.attribute(expected_type=str, allow_none=True, default=None)
 
     def __init__(self,
                  uri=None,
@@ -67,12 +70,14 @@ class Extension(Serialisable):
 
 class ExtensionList(Serialisable):
 
-    ext = Sequence(expected_type=Extension)
+    tagname = "extLst"
+
+    ext: list[Extension] = Field.sequence(expected_type=Extension, default=list)
 
     def __init__(self,
                  ext=(),
                 ):
-        self.ext = ext
+        self.ext = list(ext)
 
 
 class Relation(String):

--- a/fastpyxl/descriptors/nested.py
+++ b/fastpyxl/descriptors/nested.py
@@ -26,7 +26,7 @@ class Nested(Descriptor):
         return node.get(self.attribute)
 
     def to_tree(self, tagname=None, value=None, namespace=None):
-        namespace = getattr(self, "namespace", namespace)
+        namespace = self.namespace or namespace
         if value is not None:
             if namespace is not None:
                 tagname = "{%s}%s" % (namespace, tagname)
@@ -50,7 +50,7 @@ class NestedText(NestedValue):
         return node.text
 
     def to_tree(self, tagname=None, value=None, namespace=None):
-        namespace = getattr(self, "namespace", namespace)
+        namespace = self.namespace or namespace
         if value is not None:
             if namespace is not None:
                 tagname = "{%s}%s" % (namespace, tagname)
@@ -100,7 +100,7 @@ class EmptyTag(Nested, Bool):
 
     def to_tree(self, tagname=None, value=None, namespace=None):
         if value:
-            namespace = getattr(self, "namespace", namespace)
+            namespace = self.namespace or namespace
             if namespace is not None:
                 tagname = "{%s}%s" % (namespace, tagname)
             assert tagname is not None

--- a/fastpyxl/descriptors/serialisable.py
+++ b/fastpyxl/descriptors/serialisable.py
@@ -98,7 +98,7 @@ class Serialisable(metaclass=MetaSerialisable):
             tagname = tagname[1:]
 
         tagname = namespaced(self, tagname, namespace)
-        namespace = getattr(self, "namespace", namespace)
+        namespace = self.namespace
 
         attrs = dict(self)
         for key, ns in self.__namespaced__ or ():

--- a/fastpyxl/drawing/colors.py
+++ b/fastpyxl/drawing/colors.py
@@ -1,15 +1,13 @@
 # Copyright (c) 2010-2024 fastpyxl
 
-from fastpyxl.descriptors.serialisable import Serialisable
 from fastpyxl.descriptors import (
     Typed,
-    Set,
 )
 from fastpyxl.styles.colors import aRGB_REGEX
 from fastpyxl.xml.constants import DRAWING_NS
 from fastpyxl.xml.functions import Element
 from fastpyxl.typed_serialisable.render import namespaced_tag
-from fastpyxl.typed_serialisable.base import Serialisable as TypedSerialisable
+from fastpyxl.typed_serialisable.base import Serialisable
 from fastpyxl.typed_serialisable.errors import FieldValidationError
 from fastpyxl.typed_serialisable.fields import AliasField, Field
 
@@ -131,7 +129,7 @@ def _drawml_empty_element(tag, value, ns=None):
     return Element(namespaced_tag(tag, ns or DRAWING_NS))
 
 
-class Transform(TypedSerialisable):
+class Transform(Serialisable):
 
     tagname = "comp"
 
@@ -139,7 +137,7 @@ class Transform(TypedSerialisable):
         pass
 
 
-class SystemColor(TypedSerialisable):
+class SystemColor(Serialisable):
 
     tagname = "sysClr"
     namespace = DRAWING_NS
@@ -280,7 +278,7 @@ class SystemColor(TypedSerialisable):
         self.invGamma = invGamma
 
 
-class HSLColor(TypedSerialisable):
+class HSLColor(Serialisable):
 
     tagname = "hslClr"
 
@@ -309,7 +307,7 @@ class HSLColor(TypedSerialisable):
 
 
 
-class RGBPercent(TypedSerialisable):
+class RGBPercent(Serialisable):
 
     tagname = "rgbClr"
 
@@ -341,7 +339,7 @@ class RGBPercent(TypedSerialisable):
         self.b = b
 
 
-class SchemeColor(TypedSerialisable):
+class SchemeColor(Serialisable):
 
     tagname = "schemeClr"
     namespace = DRAWING_NS
@@ -481,7 +479,7 @@ class SchemeColor(TypedSerialisable):
         self.invGamma = invGamma
         self.val = val
 
-class ColorChoice(TypedSerialisable):
+class ColorChoice(Serialisable):
 
     tagname = "colorChoice"
     namespace = DRAWING_NS
@@ -520,23 +518,27 @@ _COLOR_SET = ('dk1', 'lt1', 'dk2', 'lt2', 'accent1', 'accent2', 'accent3',
                'accent4', 'accent5', 'accent6', 'hlink', 'folHlink')
 
 
+def _color_set_converter(v):
+    return _enum_converter(v, _COLOR_SET, "color")
+
+
 class ColorMapping(Serialisable):
 
     tagname = "clrMapOvr"
 
-    bg1 = Set(values=_COLOR_SET)
-    tx1 = Set(values=_COLOR_SET)
-    bg2 = Set(values=_COLOR_SET)
-    tx2 = Set(values=_COLOR_SET)
-    accent1 = Set(values=_COLOR_SET)
-    accent2 = Set(values=_COLOR_SET)
-    accent3 = Set(values=_COLOR_SET)
-    accent4 = Set(values=_COLOR_SET)
-    accent5 = Set(values=_COLOR_SET)
-    accent6 = Set(values=_COLOR_SET)
-    hlink = Set(values=_COLOR_SET)
-    folHlink = Set(values=_COLOR_SET)
-    extLst = Typed(expected_type=OfficeArtExtensionList, allow_none=True)
+    bg1: str | None = Field.attribute(expected_type=str, allow_none=True, converter=_color_set_converter, default=None)
+    tx1: str | None = Field.attribute(expected_type=str, allow_none=True, converter=_color_set_converter, default=None)
+    bg2: str | None = Field.attribute(expected_type=str, allow_none=True, converter=_color_set_converter, default=None)
+    tx2: str | None = Field.attribute(expected_type=str, allow_none=True, converter=_color_set_converter, default=None)
+    accent1: str | None = Field.attribute(expected_type=str, allow_none=True, converter=_color_set_converter, default=None)
+    accent2: str | None = Field.attribute(expected_type=str, allow_none=True, converter=_color_set_converter, default=None)
+    accent3: str | None = Field.attribute(expected_type=str, allow_none=True, converter=_color_set_converter, default=None)
+    accent4: str | None = Field.attribute(expected_type=str, allow_none=True, converter=_color_set_converter, default=None)
+    accent5: str | None = Field.attribute(expected_type=str, allow_none=True, converter=_color_set_converter, default=None)
+    accent6: str | None = Field.attribute(expected_type=str, allow_none=True, converter=_color_set_converter, default=None)
+    hlink: str | None = Field.attribute(expected_type=str, allow_none=True, converter=_color_set_converter, default=None)
+    folHlink: str | None = Field.attribute(expected_type=str, allow_none=True, converter=_color_set_converter, default=None)
+    extLst: OfficeArtExtensionList | None = Field.element(expected_type=OfficeArtExtensionList, allow_none=True, default=None)
 
     def __init__(self,
                  bg1="lt1",
@@ -581,7 +583,7 @@ class ColorChoiceDescriptor(Typed):
         if isinstance(value, str):
             value = ColorChoice(srgbClr=value)
         else:
-            if hasattr(self, "namespace") and value is not None:
+            if self.namespace is not None and value is not None:
                 value.namespace = self.namespace
         super().__set__(instance, value)
 

--- a/fastpyxl/drawing/effect.py
+++ b/fastpyxl/drawing/effect.py
@@ -1,18 +1,13 @@
 # Copyright (c) 2010-2024 fastpyxl
 
-from fastpyxl.descriptors.serialisable import Serialisable
-from fastpyxl.descriptors import (
-    Set,
-    Integer,
-)
-from fastpyxl.typed_serialisable.base import Serialisable as TypedSerialisable
+from fastpyxl.typed_serialisable.base import Serialisable
 from fastpyxl.typed_serialisable.errors import FieldValidationError
 from fastpyxl.typed_serialisable.fields import Field
 
 from .colors import ColorChoice
 
 
-class TintEffect(TypedSerialisable):
+class TintEffect(Serialisable):
 
     tagname = "tint"
 
@@ -27,7 +22,7 @@ class TintEffect(TypedSerialisable):
         self.amt = amt
 
 
-class LuminanceEffect(TypedSerialisable):
+class LuminanceEffect(Serialisable):
 
     tagname = "lum"
 
@@ -44,9 +39,11 @@ class LuminanceEffect(TypedSerialisable):
 
 class HSLEffect(Serialisable):
 
-    hue = Integer()
-    sat = Integer()
-    lum = Integer()
+    tagname = "hsl"
+
+    hue: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    sat: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    lum: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
 
     def __init__(self,
                  hue=None,
@@ -58,14 +55,21 @@ class HSLEffect(Serialisable):
         self.lum = lum
 
 
-class GrayscaleEffect(TypedSerialisable):
+class GrayscaleEffect(Serialisable):
 
     tagname = "grayscl"
 
 
 class FillOverlayEffect(Serialisable):
 
-    blend = Set(values=(['over', 'mult', 'screen', 'darken', 'lighten']))
+    tagname = "fillOverlay"
+
+    blend: str | None = Field.attribute(
+        expected_type=str,
+        allow_none=True,
+        converter=lambda v: _enum_converter(v, ('over', 'mult', 'screen', 'darken', 'lighten'), "blend"),
+        default=None,
+    )
 
     def __init__(self,
                  blend=None,
@@ -75,17 +79,20 @@ class FillOverlayEffect(Serialisable):
 
 class DuotoneEffect(Serialisable):
 
-    pass
+    tagname = "duotone"
+
 
 class ColorReplaceEffect(Serialisable):
 
-    pass
+    tagname = "clrRepl"
+
 
 class Color(Serialisable):
 
-    pass
+    tagname = "clr"
 
-class ColorChangeEffect(TypedSerialisable):
+
+class ColorChangeEffect(Serialisable):
 
     useA: bool | None = Field.attribute(expected_type=bool, allow_none=True, default=None)
     clrFrom: Color | None = Field.element(expected_type=Color, allow_none=True, default=None)
@@ -102,7 +109,7 @@ class ColorChangeEffect(TypedSerialisable):
         self.clrTo = clrTo
 
 
-class BlurEffect(TypedSerialisable):
+class BlurEffect(Serialisable):
 
     rad: float | None = Field.attribute(expected_type=float, allow_none=True, default=None)
     grow: bool | None = Field.attribute(expected_type=bool, allow_none=True, default=None)
@@ -115,7 +122,7 @@ class BlurEffect(TypedSerialisable):
         self.grow = grow
 
 
-class BiLevelEffect(TypedSerialisable):
+class BiLevelEffect(Serialisable):
 
     thresh: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
 
@@ -125,7 +132,7 @@ class BiLevelEffect(TypedSerialisable):
         self.thresh = thresh
 
 
-class AlphaReplaceEffect(TypedSerialisable):
+class AlphaReplaceEffect(Serialisable):
 
     a: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
 
@@ -135,7 +142,7 @@ class AlphaReplaceEffect(TypedSerialisable):
         self.a = a
 
 
-class AlphaModulateFixedEffect(TypedSerialisable):
+class AlphaModulateFixedEffect(Serialisable):
 
     amt: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
 
@@ -145,7 +152,7 @@ class AlphaModulateFixedEffect(TypedSerialisable):
         self.amt = amt
 
 
-class EffectContainer(TypedSerialisable):
+class EffectContainer(Serialisable):
 
     type: str | None = Field.attribute(
         expected_type=str,
@@ -162,7 +169,7 @@ class EffectContainer(TypedSerialisable):
         self.name = name
 
 
-class AlphaModulateEffect(TypedSerialisable):
+class AlphaModulateEffect(Serialisable):
 
     cont: EffectContainer | None = Field.element(expected_type=EffectContainer, allow_none=True, default=None)
 
@@ -174,17 +181,20 @@ class AlphaModulateEffect(TypedSerialisable):
 
 class AlphaInverseEffect(Serialisable):
 
-    pass
+    tagname = "alphaInv"
+
 
 class AlphaFloorEffect(Serialisable):
 
-    pass
+    tagname = "alphaFloor"
+
 
 class AlphaCeilingEffect(Serialisable):
 
-    pass
+    tagname = "alphaCeiling"
 
-class AlphaBiLevelEffect(TypedSerialisable):
+
+class AlphaBiLevelEffect(Serialisable):
 
     thresh: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
 
@@ -284,7 +294,7 @@ class PresetShadowEffect(ColorChoice):
         super().__init__(**kw)
 
 
-class ReflectionEffect(TypedSerialisable):
+class ReflectionEffect(Serialisable):
 
     blurRad: float | None = Field.attribute(expected_type=float, allow_none=True, default=None)
     stA: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
@@ -337,7 +347,7 @@ class ReflectionEffect(TypedSerialisable):
         self.rotWithShape = rotWithShape
 
 
-class SoftEdgesEffect(TypedSerialisable):
+class SoftEdgesEffect(Serialisable):
 
     rad: float | None = Field.attribute(expected_type=float, allow_none=True, default=None)
 
@@ -347,7 +357,7 @@ class SoftEdgesEffect(TypedSerialisable):
         self.rad = rad
 
 
-class EffectList(TypedSerialisable):
+class EffectList(Serialisable):
 
     blur: BlurEffect | None = Field.element(expected_type=BlurEffect, allow_none=True, default=None)
     fillOverlay: FillOverlayEffect | None = Field.element(expected_type=FillOverlayEffect, allow_none=True, default=None)

--- a/fastpyxl/drawing/geometry.py
+++ b/fastpyxl/drawing/geometry.py
@@ -1,23 +1,11 @@
 # Copyright (c) 2010-2024 fastpyxl
 
-from fastpyxl.descriptors.serialisable import Serialisable
-from fastpyxl.descriptors import (
-    Typed,
-    Float,
-    Integer,
-    Bool,
-    MinMax,
-    Set,
-    NoneSet,
-    String,
-)
-from fastpyxl.descriptors.excel import Coordinate, Percentage
 from fastpyxl.descriptors.excel import ExtensionList as OfficeArtExtensionList
 from .line import LineProperties  # noqa: F401 -- re-exported
 
 from fastpyxl.styles.colors import Color
 from fastpyxl.xml.constants import DRAWING_NS
-from fastpyxl.typed_serialisable.base import Serialisable as TypedSerialisable
+from fastpyxl.typed_serialisable.base import Serialisable
 from fastpyxl.typed_serialisable.errors import FieldValidationError
 from fastpyxl.typed_serialisable.fields import AliasField, Field
 
@@ -31,7 +19,27 @@ def _emu_coord(value, field_name: str):
         raise FieldValidationError(f"{field_name} rejected value {value!r}") from exc
 
 
-class Point2D(TypedSerialisable):
+def _enum_converter(value, allowed_values, field_name: str):
+    if value is None:
+        return None
+    if value not in allowed_values:
+        raise FieldValidationError(f"{field_name} rejected value {value!r}")
+    return value
+
+
+def _range_converter(value, *, field_name: str, min_val, max_val):
+    if value is None:
+        return None
+    try:
+        numeric = int(value)
+    except (TypeError, ValueError) as exc:
+        raise FieldValidationError(f"{field_name} rejected value {value!r}") from exc
+    if numeric < min_val or numeric > max_val:
+        raise FieldValidationError(f"{field_name} rejected value {value!r}")
+    return numeric
+
+
+class Point2D(Serialisable):
 
     tagname = "off"
     namespace = DRAWING_NS
@@ -55,7 +63,7 @@ class Point2D(TypedSerialisable):
         self.y = y
 
 
-class PositiveSize2D(TypedSerialisable):
+class PositiveSize2D(Serialisable):
 
     tagname = "ext"
     namespace = DRAWING_NS
@@ -77,7 +85,7 @@ class PositiveSize2D(TypedSerialisable):
         self.cy = cy
 
 
-class Transform2D(TypedSerialisable):
+class Transform2D(Serialisable):
 
     tagname = "xfrm"
     namespace = DRAWING_NS
@@ -110,7 +118,7 @@ class Transform2D(TypedSerialisable):
         self.chExt = chExt
 
 
-class GroupTransform2D(TypedSerialisable):
+class GroupTransform2D(Serialisable):
 
     tagname = "xfrm"
     namespace = DRAWING_NS
@@ -145,11 +153,11 @@ class GroupTransform2D(TypedSerialisable):
 
 class SphereCoords(Serialisable):
 
-    tagname = "sphereCoords" # usually
+    tagname = "sphereCoords"
 
-    lat = Integer()
-    lon = Integer()
-    rev = Integer()
+    lat: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    lon: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    rev: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
 
     def __init__(self,
                  lat=None,
@@ -161,35 +169,118 @@ class SphereCoords(Serialisable):
         self.rev = rev
 
 
+_CAMERA_PRST_VALUES = frozenset([
+    'legacyObliqueTopLeft', 'legacyObliqueTop', 'legacyObliqueTopRight', 'legacyObliqueLeft',
+    'legacyObliqueFront', 'legacyObliqueRight', 'legacyObliqueBottomLeft',
+    'legacyObliqueBottom', 'legacyObliqueBottomRight', 'legacyPerspectiveTopLeft',
+    'legacyPerspectiveTop', 'legacyPerspectiveTopRight', 'legacyPerspectiveLeft',
+    'legacyPerspectiveFront', 'legacyPerspectiveRight', 'legacyPerspectiveBottomLeft',
+    'legacyPerspectiveBottom', 'legacyPerspectiveBottomRight', 'orthographicFront',
+    'isometricTopUp', 'isometricTopDown', 'isometricBottomUp', 'isometricBottomDown',
+    'isometricLeftUp', 'isometricLeftDown', 'isometricRightUp', 'isometricRightDown',
+    'isometricOffAxis1Left', 'isometricOffAxis1Right', 'isometricOffAxis1Top',
+    'isometricOffAxis2Left', 'isometricOffAxis2Right', 'isometricOffAxis2Top',
+    'isometricOffAxis3Left', 'isometricOffAxis3Right', 'isometricOffAxis3Bottom',
+    'isometricOffAxis4Left', 'isometricOffAxis4Right', 'isometricOffAxis4Bottom',
+    'obliqueTopLeft', 'obliqueTop', 'obliqueTopRight', 'obliqueLeft', 'obliqueRight',
+    'obliqueBottomLeft', 'obliqueBottom', 'obliqueBottomRight', 'perspectiveFront',
+    'perspectiveLeft', 'perspectiveRight', 'perspectiveAbove', 'perspectiveBelow',
+    'perspectiveAboveLeftFacing', 'perspectiveAboveRightFacing',
+    'perspectiveContrastingLeftFacing', 'perspectiveContrastingRightFacing',
+    'perspectiveHeroicLeftFacing', 'perspectiveHeroicRightFacing',
+    'perspectiveHeroicExtremeLeftFacing', 'perspectiveHeroicExtremeRightFacing',
+    'perspectiveRelaxed', 'perspectiveRelaxedModerately',
+])
+
+_LIGHT_RIG_VALUES = frozenset([
+    'legacyFlat1', 'legacyFlat2', 'legacyFlat3', 'legacyFlat4', 'legacyNormal1',
+    'legacyNormal2', 'legacyNormal3', 'legacyNormal4', 'legacyHarsh1',
+    'legacyHarsh2', 'legacyHarsh3', 'legacyHarsh4', 'threePt', 'balanced',
+    'soft', 'harsh', 'flood', 'contrasting', 'morning', 'sunrise', 'sunset',
+    'chilly', 'freezing', 'flat', 'twoPt', 'glow', 'brightRoom',
+])
+
+_DIR_VALUES = frozenset(['tl', 't', 'tr', 'l', 'r', 'bl', 'b', 'br'])
+
+_BEVEL_VALUES = frozenset([
+    'relaxedInset', 'circle', 'slope', 'cross', 'angle',
+    'softRound', 'convex', 'coolSlant', 'divot', 'riblet',
+    'hardEdge', 'artDeco',
+])
+
+_PRST_MATERIAL_VALUES = frozenset([
+    'legacyMatte', 'legacyPlastic', 'legacyMetal', 'legacyWireframe', 'matte', 'plastic',
+    'metal', 'warmMatte', 'translucentPowder', 'powder', 'dkEdge',
+    'softEdge', 'clear', 'flat', 'softmetal',
+])
+
+_FILL_VALUES = frozenset(['norm', 'lighten', 'lightenLess', 'darken', 'darkenLess'])
+
+_FONT_REF_VALUES = frozenset(['major', 'minor'])
+
+_PRST_GEOM_VALUES = frozenset([
+    'line', 'lineInv', 'triangle', 'rtTriangle', 'rect',
+    'diamond', 'parallelogram', 'trapezoid', 'nonIsoscelesTrapezoid',
+    'pentagon', 'hexagon', 'heptagon', 'octagon', 'decagon', 'dodecagon',
+    'star4', 'star5', 'star6', 'star7', 'star8', 'star10', 'star12',
+    'star16', 'star24', 'star32', 'roundRect', 'round1Rect',
+    'round2SameRect', 'round2DiagRect', 'snipRoundRect', 'snip1Rect',
+    'snip2SameRect', 'snip2DiagRect', 'plaque', 'ellipse', 'teardrop',
+    'homePlate', 'chevron', 'pieWedge', 'pie', 'blockArc', 'donut',
+    'noSmoking', 'rightArrow', 'leftArrow', 'upArrow', 'downArrow',
+    'stripedRightArrow', 'notchedRightArrow', 'bentUpArrow',
+    'leftRightArrow', 'upDownArrow', 'leftUpArrow', 'leftRightUpArrow',
+    'quadArrow', 'leftArrowCallout', 'rightArrowCallout', 'upArrowCallout',
+    'downArrowCallout', 'leftRightArrowCallout', 'upDownArrowCallout',
+    'quadArrowCallout', 'bentArrow', 'uturnArrow', 'circularArrow',
+    'leftCircularArrow', 'leftRightCircularArrow', 'curvedRightArrow',
+    'curvedLeftArrow', 'curvedUpArrow', 'curvedDownArrow', 'swooshArrow',
+    'cube', 'can', 'lightningBolt', 'heart', 'sun', 'moon', 'smileyFace',
+    'irregularSeal1', 'irregularSeal2', 'foldedCorner', 'bevel', 'frame',
+    'halfFrame', 'corner', 'diagStripe', 'chord', 'arc', 'leftBracket',
+    'rightBracket', 'leftBrace', 'rightBrace', 'bracketPair', 'bracePair',
+    'straightConnector1', 'bentConnector2', 'bentConnector3',
+    'bentConnector4', 'bentConnector5', 'curvedConnector2',
+    'curvedConnector3', 'curvedConnector4', 'curvedConnector5', 'callout1',
+    'callout2', 'callout3', 'accentCallout1', 'accentCallout2',
+    'accentCallout3', 'borderCallout1', 'borderCallout2', 'borderCallout3',
+    'accentBorderCallout1', 'accentBorderCallout2', 'accentBorderCallout3',
+    'wedgeRectCallout', 'wedgeRoundRectCallout', 'wedgeEllipseCallout',
+    'cloudCallout', 'cloud', 'ribbon', 'ribbon2', 'ellipseRibbon',
+    'ellipseRibbon2', 'leftRightRibbon', 'verticalScroll',
+    'horizontalScroll', 'wave', 'doubleWave', 'plus', 'flowChartProcess',
+    'flowChartDecision', 'flowChartInputOutput',
+    'flowChartPredefinedProcess', 'flowChartInternalStorage',
+    'flowChartDocument', 'flowChartMultidocument', 'flowChartTerminator',
+    'flowChartPreparation', 'flowChartManualInput',
+    'flowChartManualOperation', 'flowChartConnector', 'flowChartPunchedCard',
+    'flowChartPunchedTape', 'flowChartSummingJunction', 'flowChartOr',
+    'flowChartCollate', 'flowChartSort', 'flowChartExtract',
+    'flowChartMerge', 'flowChartOfflineStorage', 'flowChartOnlineStorage',
+    'flowChartMagneticTape', 'flowChartMagneticDisk',
+    'flowChartMagneticDrum', 'flowChartDisplay', 'flowChartDelay',
+    'flowChartAlternateProcess', 'flowChartOffpageConnector',
+    'actionButtonBlank', 'actionButtonHome', 'actionButtonHelp',
+    'actionButtonInformation', 'actionButtonForwardNext',
+    'actionButtonBackPrevious', 'actionButtonEnd', 'actionButtonBeginning',
+    'actionButtonReturn', 'actionButtonDocument', 'actionButtonSound',
+    'actionButtonMovie', 'gear6', 'gear9', 'funnel', 'mathPlus', 'mathMinus',
+    'mathMultiply', 'mathDivide', 'mathEqual', 'mathNotEqual', 'cornerTabs',
+    'squareTabs', 'plaqueTabs', 'chartX', 'chartStar', 'chartPlus',
+])
+
+
 class Camera(Serialisable):
 
     tagname = "camera"
 
-    prst = Set(values=[
-        'legacyObliqueTopLeft', 'legacyObliqueTop', 'legacyObliqueTopRight', 'legacyObliqueLeft',
-         'legacyObliqueFront', 'legacyObliqueRight', 'legacyObliqueBottomLeft',
-         'legacyObliqueBottom', 'legacyObliqueBottomRight', 'legacyPerspectiveTopLeft',
-         'legacyPerspectiveTop', 'legacyPerspectiveTopRight', 'legacyPerspectiveLeft',
-         'legacyPerspectiveFront', 'legacyPerspectiveRight', 'legacyPerspectiveBottomLeft',
-         'legacyPerspectiveBottom', 'legacyPerspectiveBottomRight', 'orthographicFront',
-         'isometricTopUp', 'isometricTopDown', 'isometricBottomUp', 'isometricBottomDown',
-         'isometricLeftUp', 'isometricLeftDown', 'isometricRightUp', 'isometricRightDown',
-         'isometricOffAxis1Left', 'isometricOffAxis1Right', 'isometricOffAxis1Top',
-         'isometricOffAxis2Left', 'isometricOffAxis2Right', 'isometricOffAxis2Top',
-         'isometricOffAxis3Left', 'isometricOffAxis3Right', 'isometricOffAxis3Bottom',
-         'isometricOffAxis4Left', 'isometricOffAxis4Right', 'isometricOffAxis4Bottom',
-         'obliqueTopLeft',  'obliqueTop', 'obliqueTopRight', 'obliqueLeft', 'obliqueRight',
-         'obliqueBottomLeft', 'obliqueBottom', 'obliqueBottomRight', 'perspectiveFront',
-         'perspectiveLeft', 'perspectiveRight', 'perspectiveAbove', 'perspectiveBelow',
-         'perspectiveAboveLeftFacing', 'perspectiveAboveRightFacing',
-         'perspectiveContrastingLeftFacing', 'perspectiveContrastingRightFacing',
-         'perspectiveHeroicLeftFacing', 'perspectiveHeroicRightFacing',
-         'perspectiveHeroicExtremeLeftFacing', 'perspectiveHeroicExtremeRightFacing',
-         'perspectiveRelaxed', 'perspectiveRelaxedModerately'])
-    fov = Integer(allow_none=True)
-    zoom = Typed(expected_type=Percentage, allow_none=True)
-    rot = Typed(expected_type=SphereCoords, allow_none=True)
-
+    prst: str | None = Field.attribute(
+        expected_type=str, allow_none=True,
+        converter=lambda v: _enum_converter(v, _CAMERA_PRST_VALUES, "prst"), default=None,
+    )
+    fov: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    zoom: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    rot: SphereCoords | None = Field.element(expected_type=SphereCoords, allow_none=True, default=None)
 
     def __init__(self,
                  prst=None,
@@ -207,14 +298,15 @@ class LightRig(Serialisable):
 
     tagname = "lightRig"
 
-    rig = Set(values=['legacyFlat1', 'legacyFlat2', 'legacyFlat3', 'legacyFlat4', 'legacyNormal1',
-         'legacyNormal2', 'legacyNormal3', 'legacyNormal4', 'legacyHarsh1',
-         'legacyHarsh2', 'legacyHarsh3', 'legacyHarsh4', 'threePt', 'balanced',
-         'soft', 'harsh', 'flood', 'contrasting', 'morning', 'sunrise', 'sunset',
-         'chilly', 'freezing', 'flat', 'twoPt', 'glow', 'brightRoom']
+    rig: str | None = Field.attribute(
+        expected_type=str, allow_none=True,
+        converter=lambda v: _enum_converter(v, _LIGHT_RIG_VALUES, "rig"), default=None,
     )
-    dir = Set(values=(['tl', 't', 'tr', 'l', 'r', 'bl', 'b', 'br']))
-    rot = Typed(expected_type=SphereCoords, allow_none=True)
+    dir: str | None = Field.attribute(
+        expected_type=str, allow_none=True,
+        converter=lambda v: _enum_converter(v, _DIR_VALUES, "dir"), default=None,
+    )
+    rot: SphereCoords | None = Field.element(expected_type=SphereCoords, allow_none=True, default=None)
 
     def __init__(self,
                  rig=None,
@@ -230,9 +322,9 @@ class Vector3D(Serialisable):
 
     tagname = "vector"
 
-    dx = Integer() # can be in or universl measure :-/
-    dy = Integer()
-    dz = Integer()
+    dx: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    dy: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    dz: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
 
     def __init__(self,
                  dx=None,
@@ -248,9 +340,9 @@ class Point3D(Serialisable):
 
     tagname = "anchor"
 
-    x = Integer()
-    y = Integer()
-    z = Integer()
+    x: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    y: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    z: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
 
     def __init__(self,
                  x=None,
@@ -264,10 +356,12 @@ class Point3D(Serialisable):
 
 class Backdrop(Serialisable):
 
-    anchor = Typed(expected_type=Point3D, )
-    norm = Typed(expected_type=Vector3D, )
-    up = Typed(expected_type=Vector3D, )
-    extLst = Typed(expected_type=OfficeArtExtensionList, allow_none=True)
+    tagname = "backdrop"
+
+    anchor: Point3D | None = Field.element(expected_type=Point3D, allow_none=True, default=None)
+    norm: Vector3D | None = Field.element(expected_type=Vector3D, allow_none=True, default=None)
+    up: Vector3D | None = Field.element(expected_type=Vector3D, allow_none=True, default=None)
+    extLst: OfficeArtExtensionList | None = Field.element(expected_type=OfficeArtExtensionList, allow_none=True, default=None)
 
     def __init__(self,
                  anchor=None,
@@ -283,10 +377,12 @@ class Backdrop(Serialisable):
 
 class Scene3D(Serialisable):
 
-    camera = Typed(expected_type=Camera, )
-    lightRig = Typed(expected_type=LightRig, )
-    backdrop = Typed(expected_type=Backdrop, allow_none=True)
-    extLst = Typed(expected_type=OfficeArtExtensionList, allow_none=True)
+    tagname = "scene3d"
+
+    camera: Camera | None = Field.element(expected_type=Camera, allow_none=True, default=None)
+    lightRig: LightRig | None = Field.element(expected_type=LightRig, allow_none=True, default=None)
+    backdrop: Backdrop | None = Field.element(expected_type=Backdrop, allow_none=True, default=None)
+    extLst: OfficeArtExtensionList | None = Field.element(expected_type=OfficeArtExtensionList, allow_none=True, default=None)
 
     def __init__(self,
                  camera=None,
@@ -304,13 +400,12 @@ class Bevel(Serialisable):
 
     tagname = "bevel"
 
-    w = Integer()
-    h = Integer()
-    prst = NoneSet(values=
-               ['relaxedInset', 'circle', 'slope', 'cross', 'angle',
-                'softRound', 'convex', 'coolSlant', 'divot', 'riblet',
-                 'hardEdge', 'artDeco']
-               )
+    w: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    h: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    prst: str | None = Field.attribute(
+        expected_type=str, allow_none=True,
+        converter=lambda v: _enum_converter(v, _BEVEL_VALUES, "prst"), default=None,
+    )
 
     def __init__(self,
                  w=None,
@@ -324,21 +419,21 @@ class Bevel(Serialisable):
 
 class Shape3D(Serialisable):
 
+    tagname = "sp3d"
     namespace = DRAWING_NS
 
-    z = Typed(expected_type=Coordinate, allow_none=True)
-    extrusionH = Integer(allow_none=True)
-    contourW = Integer(allow_none=True)
-    prstMaterial = NoneSet(values=[
-        'legacyMatte','legacyPlastic', 'legacyMetal', 'legacyWireframe', 'matte', 'plastic',
-        'metal', 'warmMatte', 'translucentPowder', 'powder', 'dkEdge',
-        'softEdge', 'clear', 'flat', 'softmetal']
-                       )
-    bevelT = Typed(expected_type=Bevel, allow_none=True)
-    bevelB = Typed(expected_type=Bevel, allow_none=True)
-    extrusionClr = Typed(expected_type=Color, allow_none=True)
-    contourClr = Typed(expected_type=Color, allow_none=True)
-    extLst = Typed(expected_type=OfficeArtExtensionList, allow_none=True)
+    z: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    extrusionH: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    contourW: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    prstMaterial: str | None = Field.attribute(
+        expected_type=str, allow_none=True,
+        converter=lambda v: _enum_converter(v, _PRST_MATERIAL_VALUES, "prstMaterial"), default=None,
+    )
+    bevelT: Bevel | None = Field.element(expected_type=Bevel, allow_none=True, default=None)
+    bevelB: Bevel | None = Field.element(expected_type=Bevel, allow_none=True, default=None)
+    extrusionClr: Color | None = Field.element(expected_type=Color, allow_none=True, default=None)
+    contourClr: Color | None = Field.element(expected_type=Color, allow_none=True, default=None)
+    extLst: OfficeArtExtensionList | None = Field.element(expected_type=OfficeArtExtensionList, allow_none=True, default=None)
 
     def __init__(self,
                  z=None,
@@ -364,11 +459,16 @@ class Shape3D(Serialisable):
 
 class Path2D(Serialisable):
 
-    w = Float()
-    h = Float()
-    fill = NoneSet(values=(['norm', 'lighten', 'lightenLess', 'darken', 'darkenLess']))
-    stroke = Bool(allow_none=True)
-    extrusionOk = Bool(allow_none=True)
+    tagname = "path"
+
+    w: float | None = Field.attribute(expected_type=float, allow_none=True, default=None)
+    h: float | None = Field.attribute(expected_type=float, allow_none=True, default=None)
+    fill: str | None = Field.attribute(
+        expected_type=str, allow_none=True,
+        converter=lambda v: _enum_converter(v, _FILL_VALUES, "fill"), default=None,
+    )
+    stroke: bool | None = Field.attribute(expected_type=bool, allow_none=True, default=None)
+    extrusionOk: bool | None = Field.attribute(expected_type=bool, allow_none=True, default=None)
 
     def __init__(self,
                  w=None,
@@ -386,7 +486,9 @@ class Path2D(Serialisable):
 
 class Path2DList(Serialisable):
 
-    path = Typed(expected_type=Path2D, allow_none=True)
+    tagname = "pathLst"
+
+    path: Path2D | None = Field.element(expected_type=Path2D, allow_none=True, default=None)
 
     def __init__(self,
                  path=None,
@@ -396,10 +498,12 @@ class Path2DList(Serialisable):
 
 class GeomRect(Serialisable):
 
-    l = Coordinate()  # noqa: E741
-    t = Coordinate()
-    r = Coordinate()
-    b = Coordinate()
+    tagname = "rect"
+
+    l: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    t: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    r: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    b: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
 
     def __init__(
                  self,
@@ -416,8 +520,10 @@ class GeomRect(Serialisable):
 
 class AdjPoint2D(Serialisable):
 
-    x = Coordinate()
-    y = Coordinate()
+    tagname = "pt"
+
+    x: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    y: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
 
     def __init__(self,
                  x=None,
@@ -429,8 +535,10 @@ class AdjPoint2D(Serialisable):
 
 class ConnectionSite(Serialisable):
 
-    ang = MinMax(min=0, max=360) # guess work, can also be a name
-    pos = Typed(expected_type=AdjPoint2D, )
+    tagname = "cxn"
+
+    ang: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
+    pos: AdjPoint2D | None = Field.element(expected_type=AdjPoint2D, allow_none=True, default=None)
 
     def __init__(self,
                  ang=None,
@@ -442,7 +550,9 @@ class ConnectionSite(Serialisable):
 
 class ConnectionSiteList(Serialisable):
 
-    cxn = Typed(expected_type=ConnectionSite, allow_none=True)
+    tagname = "cxnLst"
+
+    cxn: ConnectionSite | None = Field.element(expected_type=ConnectionSite, allow_none=True, default=None)
 
     def __init__(self,
                  cxn=None,
@@ -452,12 +562,15 @@ class ConnectionSiteList(Serialisable):
 
 class AdjustHandleList(Serialisable):
 
-    pass
+    tagname = "ahLst"
+
 
 class GeomGuide(Serialisable):
 
-    name = String()
-    fmla = String()
+    tagname = "gd"
+
+    name: str | None = Field.attribute(expected_type=str, allow_none=True, default=None)
+    fmla: str | None = Field.attribute(expected_type=str, allow_none=True, default=None)
 
     def __init__(self,
                  name=None,
@@ -469,7 +582,9 @@ class GeomGuide(Serialisable):
 
 class GeomGuideList(Serialisable):
 
-    gd = Typed(expected_type=GeomGuide, allow_none=True)
+    tagname = "gdLst"
+
+    gd: GeomGuide | None = Field.element(expected_type=GeomGuide, allow_none=True, default=None)
 
     def __init__(self,
                  gd=None,
@@ -479,12 +594,13 @@ class GeomGuideList(Serialisable):
 
 class CustomGeometry2D(Serialisable):
 
-    avLst = Typed(expected_type=GeomGuideList, allow_none=True)
-    gdLst = Typed(expected_type=GeomGuideList, allow_none=True)
-    ahLst = Typed(expected_type=AdjustHandleList, allow_none=True)
-    cxnLst = Typed(expected_type=ConnectionSiteList, allow_none=True)
-    #rect = Typed(expected_type=GeomRect, allow_none=True)
-    pathLst = Typed(expected_type=Path2DList, )
+    tagname = "custGeom"
+
+    avLst: GeomGuideList | None = Field.element(expected_type=GeomGuideList, allow_none=True, default=None)
+    gdLst: GeomGuideList | None = Field.element(expected_type=GeomGuideList, allow_none=True, default=None)
+    ahLst: AdjustHandleList | None = Field.element(expected_type=AdjustHandleList, allow_none=True, default=None)
+    cxnLst: ConnectionSiteList | None = Field.element(expected_type=ConnectionSiteList, allow_none=True, default=None)
+    pathLst: Path2DList | None = Field.element(expected_type=Path2DList, allow_none=True, default=None)
 
     def __init__(self,
                  avLst=None,
@@ -504,58 +620,14 @@ class CustomGeometry2D(Serialisable):
 
 class PresetGeometry2D(Serialisable):
 
+    tagname = "prstGeom"
     namespace = DRAWING_NS
 
-    prst = Set(values=(
-        ['line', 'lineInv', 'triangle', 'rtTriangle', 'rect',
-         'diamond', 'parallelogram', 'trapezoid', 'nonIsoscelesTrapezoid',
-         'pentagon', 'hexagon', 'heptagon', 'octagon', 'decagon', 'dodecagon',
-         'star4', 'star5', 'star6', 'star7', 'star8', 'star10', 'star12',
-         'star16', 'star24', 'star32', 'roundRect', 'round1Rect',
-         'round2SameRect', 'round2DiagRect', 'snipRoundRect', 'snip1Rect',
-         'snip2SameRect', 'snip2DiagRect', 'plaque', 'ellipse', 'teardrop',
-         'homePlate', 'chevron', 'pieWedge', 'pie', 'blockArc', 'donut',
-         'noSmoking', 'rightArrow', 'leftArrow', 'upArrow', 'downArrow',
-         'stripedRightArrow', 'notchedRightArrow', 'bentUpArrow',
-         'leftRightArrow', 'upDownArrow', 'leftUpArrow', 'leftRightUpArrow',
-         'quadArrow', 'leftArrowCallout', 'rightArrowCallout', 'upArrowCallout',
-         'downArrowCallout', 'leftRightArrowCallout', 'upDownArrowCallout',
-         'quadArrowCallout', 'bentArrow', 'uturnArrow', 'circularArrow',
-         'leftCircularArrow', 'leftRightCircularArrow', 'curvedRightArrow',
-         'curvedLeftArrow', 'curvedUpArrow', 'curvedDownArrow', 'swooshArrow',
-         'cube', 'can', 'lightningBolt', 'heart', 'sun', 'moon', 'smileyFace',
-         'irregularSeal1', 'irregularSeal2', 'foldedCorner', 'bevel', 'frame',
-         'halfFrame', 'corner', 'diagStripe', 'chord', 'arc', 'leftBracket',
-         'rightBracket', 'leftBrace', 'rightBrace', 'bracketPair', 'bracePair',
-         'straightConnector1', 'bentConnector2', 'bentConnector3',
-         'bentConnector4', 'bentConnector5', 'curvedConnector2',
-         'curvedConnector3', 'curvedConnector4', 'curvedConnector5', 'callout1',
-         'callout2', 'callout3', 'accentCallout1', 'accentCallout2',
-         'accentCallout3', 'borderCallout1', 'borderCallout2', 'borderCallout3',
-         'accentBorderCallout1', 'accentBorderCallout2', 'accentBorderCallout3',
-         'wedgeRectCallout', 'wedgeRoundRectCallout', 'wedgeEllipseCallout',
-         'cloudCallout', 'cloud', 'ribbon', 'ribbon2', 'ellipseRibbon',
-         'ellipseRibbon2', 'leftRightRibbon', 'verticalScroll',
-         'horizontalScroll', 'wave', 'doubleWave', 'plus', 'flowChartProcess',
-         'flowChartDecision', 'flowChartInputOutput',
-         'flowChartPredefinedProcess', 'flowChartInternalStorage',
-         'flowChartDocument', 'flowChartMultidocument', 'flowChartTerminator',
-         'flowChartPreparation', 'flowChartManualInput',
-         'flowChartManualOperation', 'flowChartConnector', 'flowChartPunchedCard',
-         'flowChartPunchedTape', 'flowChartSummingJunction', 'flowChartOr',
-         'flowChartCollate', 'flowChartSort', 'flowChartExtract',
-         'flowChartMerge', 'flowChartOfflineStorage', 'flowChartOnlineStorage',
-         'flowChartMagneticTape', 'flowChartMagneticDisk',
-         'flowChartMagneticDrum', 'flowChartDisplay', 'flowChartDelay',
-         'flowChartAlternateProcess', 'flowChartOffpageConnector',
-         'actionButtonBlank', 'actionButtonHome', 'actionButtonHelp',
-         'actionButtonInformation', 'actionButtonForwardNext',
-         'actionButtonBackPrevious', 'actionButtonEnd', 'actionButtonBeginning',
-         'actionButtonReturn', 'actionButtonDocument', 'actionButtonSound',
-         'actionButtonMovie', 'gear6', 'gear9', 'funnel', 'mathPlus', 'mathMinus',
-         'mathMultiply', 'mathDivide', 'mathEqual', 'mathNotEqual', 'cornerTabs',
-         'squareTabs', 'plaqueTabs', 'chartX', 'chartStar', 'chartPlus']))
-    avLst = Typed(expected_type=GeomGuideList, allow_none=True)
+    prst: str | None = Field.attribute(
+        expected_type=str, allow_none=True,
+        converter=lambda v: _enum_converter(v, _PRST_GEOM_VALUES, "prst"), default=None,
+    )
+    avLst: GeomGuideList | None = Field.element(expected_type=GeomGuideList, allow_none=True, default=None)
 
     def __init__(self,
                  prst=None,
@@ -567,7 +639,12 @@ class PresetGeometry2D(Serialisable):
 
 class FontReference(Serialisable):
 
-    idx = NoneSet(values=(['major', 'minor']))
+    tagname = "fontRef"
+
+    idx: str | None = Field.attribute(
+        expected_type=str, allow_none=True,
+        converter=lambda v: _enum_converter(v, _FONT_REF_VALUES, "idx"), default=None,
+    )
 
     def __init__(self,
                  idx=None,
@@ -577,7 +654,9 @@ class FontReference(Serialisable):
 
 class StyleMatrixReference(Serialisable):
 
-    idx = Integer()
+    tagname = "styleRef"
+
+    idx: int | None = Field.attribute(expected_type=int, allow_none=True, default=None)
 
     def __init__(self,
                  idx=None,
@@ -587,10 +666,12 @@ class StyleMatrixReference(Serialisable):
 
 class ShapeStyle(Serialisable):
 
-    lnRef = Typed(expected_type=StyleMatrixReference, )
-    fillRef = Typed(expected_type=StyleMatrixReference, )
-    effectRef = Typed(expected_type=StyleMatrixReference, )
-    fontRef = Typed(expected_type=FontReference, )
+    tagname = "style"
+
+    lnRef: StyleMatrixReference | None = Field.element(expected_type=StyleMatrixReference, allow_none=True, default=None)
+    fillRef: StyleMatrixReference | None = Field.element(expected_type=StyleMatrixReference, allow_none=True, default=None)
+    effectRef: StyleMatrixReference | None = Field.element(expected_type=StyleMatrixReference, allow_none=True, default=None)
+    fontRef: FontReference | None = Field.element(expected_type=FontReference, allow_none=True, default=None)
 
     def __init__(self,
                  lnRef=None,

--- a/fastpyxl/formatting/rule.py
+++ b/fastpyxl/formatting/rule.py
@@ -49,7 +49,7 @@ class FormatObject(Serialisable):
     def __setattr__(self, name, value):
         if name == "val" and value is not None:
             ref = isinstance(value, str) and COORD_RE.match(value)
-            if getattr(self, "type", None) == "formula" or ref:
+            if self.type == "formula" or ref:
                 value = str(value)
             else:
                 try:

--- a/fastpyxl/packaging/core.py
+++ b/fastpyxl/packaging/core.py
@@ -25,7 +25,7 @@ class NestedDateTime(DateTime, NestedText):
     expected_type = datetime.datetime
 
     def to_tree(self, tagname=None, value=None, namespace=None):
-        namespace = getattr(self, "namespace", namespace)
+        namespace = self.namespace or namespace
         if namespace is not None:
             tagname = "{%s}%s" % (namespace, tagname)
         assert tagname is not None

--- a/fastpyxl/reader/tests/test_excel.py
+++ b/fastpyxl/reader/tests/test_excel.py
@@ -109,7 +109,7 @@ def test_close_read(datadir, load_workbook, ro):
     datadir.chdir()
 
     wb = load_workbook("complex-styles.xlsx", read_only=ro)
-    assert hasattr(wb, '_archive') is ro
+    assert (wb._archive is not None) is ro
 
     wb.close()
 

--- a/fastpyxl/styles/cell_style.py
+++ b/fastpyxl/styles/cell_style.py
@@ -116,11 +116,13 @@ class CellStyle(Serialisable):
         Convert to StyleArray
         """
         style = StyleArray()
-        for k in ("fontId", "fillId", "borderId", "numFmtId", "pivotButton",
-                  "quotePrefix", "xfId"):
-            v = getattr(self, k, 0)
+        for idx, v in (
+            (0, self.fontId), (1, self.fillId), (2, self.borderId),
+            (3, self.numFmtId), (6, self.pivotButton),
+            (7, self.quotePrefix), (8, self.xfId),
+        ):
             if v is not None:
-                setattr(style, k, v)
+                style[idx] = v
         return style
 
 

--- a/fastpyxl/styles/colors.py
+++ b/fastpyxl/styles/colors.py
@@ -103,13 +103,26 @@ class Color(Serialisable):
     def value(self):
         t = self.type
         assert t is not None
-        return getattr(self, t)
+        if t == 'rgb':
+            return self.rgb
+        if t == 'indexed':
+            return self.indexed
+        if t == 'theme':
+            return self.theme
+        return self.auto
 
     @value.setter
     def value(self, value):
         t = self.type
         assert t is not None
-        setattr(self, t, value)
+        if t == 'rgb':
+            self.rgb = value
+        elif t == 'indexed':
+            self.indexed = value
+        elif t == 'theme':
+            self.theme = value
+        else:
+            self.auto = value
 
     def __iter__(self):
         attrs = [(self.type, self.value)]

--- a/fastpyxl/styles/named_styles.py
+++ b/fastpyxl/styles/named_styles.py
@@ -70,7 +70,7 @@ class NamedStyle(Serialisable):
 
     def __setattr__(self, attr, value):
         super().__setattr__(attr, value)
-        if getattr(self, '_wb', None) and attr in (
+        if self._wb and attr in (
            'font', 'fill', 'border', 'alignment', 'number_format', 'protection',
             ):
             self._recalculate()

--- a/fastpyxl/styles/styleable.py
+++ b/fastpyxl/styles/styleable.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2010-2024 fastpyxl
 
 from copy import copy
+from operator import attrgetter
 
 from .numbers import (
     BUILTIN_FORMATS,
@@ -13,39 +14,60 @@ from .named_styles import NamedStyle
 from .builtins import styles
 
 
+# Map StyleArray attribute names to their underlying array indices.
+_STYLE_KEY_INDEX = {
+    "fontId": 0, "fillId": 1, "borderId": 2, "numFmtId": 3,
+    "protectionId": 4, "alignmentId": 5, "pivotButton": 6,
+    "quotePrefix": 7, "xfId": 8,
+}
+
+# Precomputed C-level attribute getters for workbook style collections.
+_WB_COLLECTION_GETTER = {
+    '_fonts': attrgetter('_fonts'),
+    '_fills': attrgetter('_fills'),
+    '_borders': attrgetter('_borders'),
+    '_number_formats': attrgetter('_number_formats'),
+    '_protections': attrgetter('_protections'),
+    '_alignments': attrgetter('_alignments'),
+    '_named_styles': attrgetter('_named_styles'),
+}
+
+
 class StyleDescriptor:
 
     def __init__(self, collection, key):
         self.collection = collection
         self.key = key
+        self._key_idx = _STYLE_KEY_INDEX[key]
+        self._get_collection = _WB_COLLECTION_GETTER[collection]
 
     def __set__(self, instance, value):
-        pending_styles = getattr(instance, "_pending_styles", None)
+        pending_styles = instance._pending_styles
         if pending_styles is not None:
             instance._ensure_style_array()
             pending_styles[self.key] = (self.collection, value)
             return
-        coll = getattr(instance.parent.parent, self.collection)
-        if not getattr(instance, "_style"):
+        coll = self._get_collection(instance.parent.parent)
+        if not instance._style:
             instance._style = StyleArray()
-        setattr(instance._style, self.key, coll.add(value))
+        instance._style[self._key_idx] = coll.add(value)
 
 
     def __get__(self, instance, cls):
         if instance is None:
             return self
-        pending_styles = getattr(instance, "_pending_styles", None)
+        pending_styles = instance._pending_styles
         if pending_styles is not None:
             pending = pending_styles.get(self.key)
             if pending is not None:
                 _, value = pending
                 return StyleProxy(value)
-        coll = getattr(instance.parent.parent, self.collection)
+        coll = self._get_collection(instance.parent.parent)
         if hasattr(instance, "_ensure_style_array"):
             instance._ensure_style_array()
-        elif not getattr(instance, "_style"):
+        elif not instance._style:
             instance._style = StyleArray()
-        idx = getattr(instance._style, self.key)
+        idx = instance._style[self._key_idx]
         return StyleProxy(coll[idx])
 
 
@@ -53,27 +75,29 @@ class NumberFormatDescriptor:
 
     key = "numFmtId"
     collection = '_number_formats'
+    _key_idx = _STYLE_KEY_INDEX["numFmtId"]
+    _get_collection = _WB_COLLECTION_GETTER['_number_formats']
 
     def __set__(self, instance, value):
-        pending_styles = getattr(instance, "_pending_styles", None)
+        pending_styles = instance._pending_styles
         if pending_styles is not None:
             instance._ensure_style_array()
             pending_styles[self.key] = (self.collection, value)
             return
-        coll = getattr(instance.parent.parent, self.collection)
+        coll = self._get_collection(instance.parent.parent)
         if value in BUILTIN_FORMATS_REVERSE:
             idx = BUILTIN_FORMATS_REVERSE[value]
         else:
             idx = coll.add(value) + BUILTIN_FORMATS_MAX_SIZE
-        if not getattr(instance, "_style"):
+        if not instance._style:
             instance._style = StyleArray()
-        setattr(instance._style, self.key, idx)
+        instance._style[self._key_idx] = idx
 
 
     def __get__(self, instance, cls):
         if instance is None:
             return self
-        pending_styles = getattr(instance, "_pending_styles", None)
+        pending_styles = instance._pending_styles
         if pending_styles is not None:
             pending = pending_styles.get(self.key)
             if pending is not None:
@@ -81,12 +105,12 @@ class NumberFormatDescriptor:
                 return value
         if hasattr(instance, "_ensure_style_array"):
             instance._ensure_style_array()
-        elif not getattr(instance, "_style"):
+        elif not instance._style:
             instance._style = StyleArray()
-        idx = getattr(instance._style, self.key)
+        idx = instance._style[self._key_idx]
         if idx < BUILTIN_FORMATS_MAX_SIZE:
             return BUILTIN_FORMATS.get(idx, "General")
-        coll = getattr(instance.parent.parent, self.collection)
+        coll = self._get_collection(instance.parent.parent)
         return coll[idx - BUILTIN_FORMATS_MAX_SIZE]
 
 
@@ -94,14 +118,16 @@ class NamedStyleDescriptor:
 
     key = "xfId"
     collection = "_named_styles"
+    _key_idx = _STYLE_KEY_INDEX["xfId"]
+    _get_collection = _WB_COLLECTION_GETTER['_named_styles']
 
 
     def __set__(self, instance, value):
-        if not getattr(instance, "_style"):
+        if not instance._style:
             instance._style = StyleArray()
         wb = instance.parent.parent
-        coll = getattr(wb, self.collection)
-        pending_styles = getattr(instance, "_pending_styles", None)
+        coll = self._get_collection(wb)
+        pending_styles = instance._pending_styles
         if pending_styles is not None:
             if isinstance(value, NamedStyle):
                 if value in coll:
@@ -138,15 +164,15 @@ class NamedStyleDescriptor:
     def __get__(self, instance, cls):
         if instance is None:
             return self
-        pending = getattr(instance, "_pending_named_style", None)
+        pending = instance._pending_named_style
         if pending is not None:
             if isinstance(pending, NamedStyle):
                 return pending.name
             return pending
-        if not getattr(instance, "_style"):
+        if not instance._style:
             instance._style = StyleArray()
-        idx = getattr(instance._style, self.key)
-        coll = getattr(instance.parent.parent, self.collection)
+        idx = instance._style[self._key_idx]
+        coll = self._get_collection(instance.parent.parent)
         return coll.names[idx]
 
 
@@ -154,17 +180,18 @@ class StyleArrayDescriptor:
 
     def __init__(self, key):
         self.key = key
+        self._key_idx = _STYLE_KEY_INDEX[key]
 
     def __set__(self, instance, value):
         if instance._style is None:
             instance._style = StyleArray()
-        setattr(instance._style, self.key, value)
+        instance._style[self._key_idx] = value
 
 
     def __get__(self, instance, cls):
         if instance._style is None:
             return False
-        return bool(getattr(instance._style, self.key))
+        return bool(instance._style[self._key_idx])
 
 
 class StyleableObject:
@@ -197,7 +224,7 @@ class StyleableObject:
             self._style = StyleArray()
 
     def _apply_pending_named_style(self):
-        pending = getattr(self, "_pending_named_style", None)
+        pending = self._pending_named_style
         if pending is None:
             return
         wb = self.parent.parent
@@ -226,18 +253,19 @@ class StyleableObject:
     def _apply_pending_styles(self):
         if not self._pending_styles:
             return
+        assert self._style is not None
         wb = self.parent.parent
         for key, (collection, value) in self._pending_styles.items():
             if key == "numFmtId":
                 if value in BUILTIN_FORMATS_REVERSE:
                     idx = BUILTIN_FORMATS_REVERSE[value]
                 else:
-                    coll = getattr(wb, collection)
+                    coll = _WB_COLLECTION_GETTER[collection](wb)
                     idx = coll.add(value) + BUILTIN_FORMATS_MAX_SIZE
             else:
-                coll = getattr(wb, collection)
+                coll = _WB_COLLECTION_GETTER[collection](wb)
                 idx = coll.add(value)
-            setattr(self._style, key, idx)
+            self._style[_STYLE_KEY_INDEX[key]] = idx
         self._pending_styles.clear()
 
 
@@ -251,11 +279,10 @@ class StyleableObject:
 
     @property
     def has_style(self):
-        if getattr(self, "_pending_named_style", None) is not None:
+        if self._pending_named_style is not None:
             return True
         if self._pending_styles:
             return True
         if self._style is None:
             return False
         return any(self._style)
-

--- a/fastpyxl/typed_serialisable/base.py
+++ b/fastpyxl/typed_serialisable/base.py
@@ -194,6 +194,7 @@ class Serialisable(metaclass=MetaSerialisable):
     __multi_sequence_tag_map__ = {}
     __attribute_xml_name_map__ = {}
     namespace = None
+    idx_base = 0
 
     @property
     def tagname(self):
@@ -290,7 +291,7 @@ class Serialisable(metaclass=MetaSerialisable):
         if tagname.startswith("_"):
             tagname = tagname[1:]
 
-        namespace = getattr(self, "namespace", namespace)
+        namespace = self.namespace
         root = Element(namespaced_tag(tagname, namespace))
         attrs = dict(self)
         for key, ns_key in self.__namespaced__:
@@ -339,7 +340,7 @@ class Serialisable(metaclass=MetaSerialisable):
                 if value is None:
                     continue
                 pattr = field.sequence_primitive_attribute
-                idx_base = getattr(self, "idx_base", 0)
+                idx_base = self.idx_base
                 for idx, item in enumerate(value, idx_base):
                     if supports_to_tree(item):
                         root.append(item.to_tree(tag, idx))

--- a/fastpyxl/workbook/workbook.py
+++ b/fastpyxl/workbook/workbook.py
@@ -57,7 +57,7 @@ class Workbook:
     _data_only = False
     template = False
     path = "/xl/workbook.xml"
-    _archive: Optional[ZipFile]
+    _archive: Optional[ZipFile] = None
 
     def __init__(self,
                  write_only=False,
@@ -477,7 +477,7 @@ class Workbook:
         """
         Close workbook file if open. Only affects read-only and write-only modes.
         """
-        archive = getattr(self, "_archive", None)
+        archive = self._archive
         if archive is not None:
             archive.close()
 

--- a/fastpyxl/worksheet/cell_range.py
+++ b/fastpyxl/worksheet/cell_range.py
@@ -378,9 +378,10 @@ class CellRange(Serialisable):
         """
         For use as a dictionary elsewhere in the library.
         """
-        for x in ("min_col", "min_row", "max_col", "max_row"):
-            v = getattr(self, x)
-            yield x, v
+        yield "min_col", self.min_col
+        yield "min_row", self.min_row
+        yield "max_col", self.max_col
+        yield "max_row", self.max_row
 
 
     def expand(self, right=0, down=0, left=0, up=0):

--- a/fastpyxl/worksheet/copier.py
+++ b/fastpyxl/worksheet/copier.py
@@ -54,15 +54,15 @@ class WorksheetCopy:
             if source_cell.has_style:
                 target_cell._style = copy(source_cell._style)
 
-            sp = getattr(source_cell, "_pending_styles", None)
+            sp = source_cell._pending_styles
             if sp:
-                td = getattr(target_cell, "_pending_styles", None)
+                td = target_cell._pending_styles
                 if td is None:
                     target_cell._pending_styles = {}
                     td = target_cell._pending_styles
                 td.update(sp)
 
-            pn = getattr(source_cell, "_pending_named_style", None)
+            pn = source_cell._pending_named_style
             if pn is not None:
                 target_cell._pending_named_style = pn
 
@@ -74,9 +74,10 @@ class WorksheetCopy:
 
 
     def _copy_dimensions(self):
-        for attr in ('row_dimensions', 'column_dimensions'):
-            src = getattr(self.source, attr)
-            target = getattr(self.target, attr)
+        for src, target in (
+            (self.source.row_dimensions, self.target.row_dimensions),
+            (self.source.column_dimensions, self.target.column_dimensions),
+        ):
             for key, dim in src.items():
                 target[key] = copy(dim)
                 target[key].worksheet = self.target

--- a/fastpyxl/worksheet/formula.py
+++ b/fastpyxl/worksheet/formula.py
@@ -28,8 +28,11 @@ class DataTableFormula:
 
 
     def __iter__(self):
-        for k in ["t", "ref", "dt2D", "dtr", "r1", "r2", "del1", "del2", "ca"]:
-            v = getattr(self, k)
+        for k, v in (
+            ("t", self.t), ("ref", self.ref), ("dt2D", self.dt2D),
+            ("dtr", self.dtr), ("r1", self.r1), ("r2", self.r2),
+            ("del1", self.del1), ("del2", self.del2), ("ca", self.ca),
+        ):
             if v:
                 yield k, safe_string(v)
 
@@ -45,7 +48,6 @@ class ArrayFormula:
 
 
     def __iter__(self):
-        for k in ["t", "ref"]:
-            v = getattr(self, k)
+        for k, v in (("t", self.t), ("ref", self.ref)):
             if v:
                 yield k, safe_string(v)

--- a/fastpyxl/worksheet/merge.py
+++ b/fastpyxl/worksheet/merge.py
@@ -105,16 +105,18 @@ class MergedCellRange(CellRange):
         sc = self.start_cell
         assert sc is not None
 
-        names = ['top', 'left', 'right', 'bottom']
-
         start_border = sc.border or Border()
 
-        for name in names:
-            side = getattr(start_border, name)
+        for name, side, coords in (
+            ('top', start_border.top, self.top),
+            ('left', start_border.left, self.left),
+            ('right', start_border.right, self.right),
+            ('bottom', start_border.bottom, self.bottom),
+        ):
             if side and side.style is None:
                 continue # don't need to do anything if there is no border style
             border = Border(**{name:side})
-            for coord in getattr(self, name):
+            for coord in coords:
                 cell = self.ws._cells.get(coord)
                 if cell is None:
                     row, col = coord


### PR DESCRIPTION
## Summary
- Replaced ~51 dynamic `getattr`/`setattr` calls with direct attribute access across the codebase, leveraging the static type system
- Converted `styleable.py` descriptors to use precomputed array indices and `operator.attrgetter` for cell-styling hot path
- Added class-level defaults (`namespace`, `nested`, `idx_base`, axis attrs) to enable direct access on `Descriptor`, `Serialisable`, and `ChartBase`
- Migrated all 31 old-style `descriptors.Serialisable` classes to `typed_serialisable` (drawing/geometry, drawing/effect, drawing/colors, descriptors/excel)
- Inlined fixed attribute lists in `__iter__`/`__eq__` methods (cell_range, formula, merge, cell_style, chartsheet/protection, read_only, colors)

## Test plan
- [x] `uv run ty check` passes
- [x] Full test suite passes (2736 passed, 9 skipped)
- [x] No non-test files import old-style `descriptors.serialisable.Serialisable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)