### PR TITLE
perf: reduce per-cell overhead in bind_cells / parse_cell

### DIFF
--- a/fastpyxl/worksheet/_read_only.py
+++ b/fastpyxl/worksheet/_read_only.py
@@ -109,20 +109,21 @@ class ReadOnlyWorksheet:
         if not row and not max_col: # in case someone wants to force rows where there aren't any
             return ()
 
-        max_col = max_col or  row[-1]['column']
+        max_col = max_col or  row[-1][1]
         row_width = max_col + 1 - min_col
 
         new_row = [EMPTY_CELL] * row_width
         if values_only:
             new_row = [None] * row_width
 
-        for cell in row:
-            counter = cell['column']
-            if min_col <= counter <= max_col:
-                idx = counter - min_col # position in list of cells returned
-                new_row[idx] = cell['value']
+        for cell_row, cell_col, cell_val, cell_dt, cell_sid in row:
+            if min_col <= cell_col <= max_col:
+                idx = cell_col - min_col # position in list of cells returned
+                new_row[idx] = cell_val
                 if not values_only:
-                    new_row[idx] = ReadOnlyCell(self, **cell)
+                    new_row[idx] = ReadOnlyCell(
+                        self, cell_row, cell_col, cell_val, cell_dt, cell_sid
+                    )
 
         return tuple(new_row)
 

--- a/fastpyxl/worksheet/_reader.py
+++ b/fastpyxl/worksheet/_reader.py
@@ -9,6 +9,7 @@ from fastpyxl.xml.functions import iterparse
 
 # package imports
 from fastpyxl.cell import Cell, MergedCell
+from fastpyxl.styles.cell_style import StyleArray
 from fastpyxl.cell.text import Text
 from fastpyxl.worksheet.dimensions import (
     ColumnDimension,
@@ -243,7 +244,7 @@ class WorkSheetParser:
                     else:
                         value = Text.from_tree(child).content
 
-        return {'row':row, 'column':column, 'value':value, 'data_type':data_type, 'style_id':style_id}
+        return (row, column, value, data_type, style_id)
 
 
     def parse_formula(self, element):
@@ -367,16 +368,29 @@ class WorksheetReader:
 
 
     def bind_cells(self):
+        _Cell = Cell
+        _new = _Cell.__new__
+        _StyleArray = StyleArray
+        _cell_styles = self.ws.parent._cell_styles
+        _ws = self.ws
+        _cells = _ws._cells
         for idx, row in self.parser.parse():
-            for cell in row:
-                style = self.ws.parent._cell_styles[cell['style_id']]
-                c = Cell(self.ws, row=cell['row'], column=cell['column'], style_array=style)
-                c._value = cell['value']
-                c.data_type = cell['data_type']
-                self.ws._cells[(cell['row'], cell['column'])] = c
+            for cell_row, cell_col, cell_val, cell_dt, cell_sid in row:
+                c = _new(_Cell)
+                c.parent = _ws
+                c._style = _StyleArray(_cell_styles[cell_sid])
+                c._pending_styles = {}
+                c._pending_named_style = None
+                c.row = cell_row
+                c.column = cell_col
+                c._value = cell_val
+                c.data_type = cell_dt
+                c._hyperlink = None
+                c._comment = None
+                _cells[(cell_row, cell_col)] = c
 
-        if self.ws._cells:
-            self.ws._current_row = self.ws.max_row # use cells not row dimensions
+        if _cells:
+            _ws._current_row = _ws.max_row # use cells not row dimensions
 
 
     def bind_formatting(self):

--- a/fastpyxl/worksheet/tests/test_read_only.py
+++ b/fastpyxl/worksheet/tests/test_read_only.py
@@ -74,7 +74,7 @@ class TestReadOnlyWorksheet:
 
     def test_empty_cell(self, ReadOnlyWorksheet):
         row = [
-            {'column':4, 'value':None, 'row':1},
+            (1, 4, None, 'n', 0),
         ]
         ws = ReadOnlyWorksheet
         cells = ws._get_row(row, max_col=4, values_only=True)
@@ -83,8 +83,8 @@ class TestReadOnlyWorksheet:
 
     def test_pad_row_left(self, ReadOnlyWorksheet):
         row = [
-            {'column':4, 'value':4,},
-            {'column':8, 'value':8,},
+            (1, 4, 4, 'n', 0),
+            (1, 8, 8, 'n', 0),
         ]
         ws = ReadOnlyWorksheet
         cells = ws._get_row(row, max_col=4, values_only=True)
@@ -93,8 +93,8 @@ class TestReadOnlyWorksheet:
 
     def test_pad_row(self, ReadOnlyWorksheet):
         row = [
-            {'column':4, 'value':4,},
-            {'column':8, 'value':8,},
+            (1, 4, 4, 'n', 0),
+            (1, 8, 8, 'n', 0),
         ]
         ws = ReadOnlyWorksheet
         cells = ws._get_row(row, min_col=4, max_col=8, values_only=True)
@@ -103,8 +103,8 @@ class TestReadOnlyWorksheet:
 
     def test_pad_row_right(self, ReadOnlyWorksheet):
         row = [
-            {'column':4, 'value':4},
-            {'column':8, 'value':8},
+            (1, 4, 4, 'n', 0),
+            (1, 8, 8, 'n', 0),
         ]
         ws = ReadOnlyWorksheet
         cells = ws._get_row(row, min_col=6, max_col=10, values_only=True)
@@ -113,8 +113,8 @@ class TestReadOnlyWorksheet:
 
     def test_pad_row_cells(self, ReadOnlyWorksheet):
         row = [
-            {'column':4, 'value':4, 'row':2},
-            {'column':8, 'value':8, 'row':2},
+            (2, 4, 4, 'n', 0),
+            (2, 8, 8, 'n', 0),
         ]
         ws = ReadOnlyWorksheet
         cells = ws._get_row(row, min_col=6, max_col=10)

--- a/fastpyxl/worksheet/tests/test_reader.py
+++ b/fastpyxl/worksheet/tests/test_reader.py
@@ -236,8 +236,7 @@ class TestWorksheetParser:
         element = fromstring(src)
 
         cell = parser.parse_cell(element)
-        assert cell == {'column': 1, 'data_type': 'f', 'row': 1,
-                        'style_id':0, 'value': '=IF(TRUE, "y", "n")'}
+        assert cell == (1, 1, '=IF(TRUE, "y", "n")', 'f', 0)
 
 
     def test_formula_data_only(self, WorkSheetParser):
@@ -253,8 +252,7 @@ class TestWorksheetParser:
         element = fromstring(src)
 
         cell = parser.parse_cell(element)
-        assert cell == {'column': 1, 'data_type': 'n', 'row': 1,
-                        'style_id':0, 'value': 3}
+        assert cell == (1, 1, 3, 'n', 0)
 
 
     def test_string_formula_data_only(self, WorkSheetParser):
@@ -270,8 +268,7 @@ class TestWorksheetParser:
         element = fromstring(src)
 
         cell = parser.parse_cell(element)
-        assert cell == {'column': 1, 'data_type': 's', 'row': 1,
-                        'style_id':0, 'value': 'y'}
+        assert cell == (1, 1, 'y', 's', 0)
 
 
     def test_number(self, WorkSheetParser):
@@ -285,8 +282,7 @@ class TestWorksheetParser:
         element = fromstring(src)
 
         cell = parser.parse_cell(element)
-        assert cell == {'column': 1, 'data_type': 'n', 'row': 1,
-                        'style_id':0, 'value': 1}
+        assert cell == (1, 1, 1, 'n', 0)
 
 
 
@@ -301,8 +297,7 @@ class TestWorksheetParser:
         element = fromstring(src)
 
         cell = parser.parse_cell(element)
-        assert cell == {'column': 1, 'data_type': 'd', 'row': 1,
-                        'style_id':0, 'value': datetime.datetime(2011, 12, 25, 14, 23, 55)}
+        assert cell == (1, 1, datetime.datetime(2011, 12, 25, 14, 23, 55), 'd', 0)
 
 
     def test_timedelta(self, WorkSheetParser):
@@ -316,8 +311,7 @@ class TestWorksheetParser:
         element = fromstring(src)
 
         cell = parser.parse_cell(element)
-        assert cell == {'column': 1, 'data_type': 'd', 'row': 1,
-                        'style_id':30, 'value':datetime.timedelta(days=1, hours=6)}
+        assert cell == (1, 1, datetime.timedelta(days=1, hours=6), 'd', 30)
 
 
     def test_mac_date(self, WorkSheetParser):
@@ -332,8 +326,7 @@ class TestWorksheetParser:
         element = fromstring(src)
 
         cell = parser.parse_cell(element)
-        assert cell == {'column': 1, 'data_type': 'd', 'row': 1,
-                        'style_id':29, 'value':datetime.datetime(2016, 10, 3, 0, 0)}
+        assert cell == (1, 1, datetime.datetime(2016, 10, 3, 0, 0), 'd', 29)
 
     @pytest.mark.parametrize("value", [
         -693595,
@@ -365,8 +358,7 @@ class TestWorksheetParser:
         element = fromstring(src)
 
         cell = parser.parse_cell(element)
-        assert cell == {'column': 1, 'data_type': 's', 'row': 1,
-                        'style_id':0, 'value':'a'}
+        assert cell == (1, 1, 'a', 's', 0)
 
 
     def test_boolean(self, WorkSheetParser):
@@ -380,8 +372,7 @@ class TestWorksheetParser:
         element = fromstring(src)
 
         cell = parser.parse_cell(element)
-        assert cell == {'column': 1, 'data_type': 'b', 'row': 1,
-                        'style_id':0, 'value':True}
+        assert cell == (1, 1, True, 'b', 0)
 
 
     def test_inline_string(self, WorkSheetParser):
@@ -397,8 +388,7 @@ class TestWorksheetParser:
         element = fromstring(src)
 
         cell = parser.parse_cell(element)
-        assert cell == {'column': 1, 'data_type': 's', 'row': 1,
-                        'style_id':0, 'value':"ID"}
+        assert cell == (1, 1, "ID", 's', 0)
 
 
     def test_inline_richtext(self, WorkSheetParser):
@@ -421,8 +411,7 @@ class TestWorksheetParser:
         cell = parser.parse_cell(element)
         expected = CellRichText(TextBlock(font=InlineFont(sz="8.0"),
                                            text="11 de September de 2014"))
-        assert cell == {'column': 18, 'data_type': 's', 'row':
-                        2,'style_id':4, 'value':expected}
+        assert cell == (2, 18, expected, 's', 4)
 
 
     def test_parse_richtext(self):
@@ -610,9 +599,9 @@ class TestWorksheetParser:
         element = fromstring(src)
         max_row, cells = parser.parse_row(element)
         expected = [
-            {'column': 1, 'row': 1, 'data_type': 'n', 'value': 2, 'style_id': 0},
-            {'column': 2, 'row': 1, 'data_type': 'n', 'value': 4, 'style_id': 0},
-            {'column': 3, 'row': 1, 'data_type': 'n', 'value': 3, 'style_id': 0},
+            (1, 1, 2, 'n', 0),
+            (1, 2, 4, 'n', 0),
+            (1, 3, 3, 'n', 0),
         ]
         for expected_cell, cell in zip(expected, cells):
             assert expected_cell == cell
@@ -639,10 +628,10 @@ class TestWorksheetParser:
         element = fromstring(src)
         _, cells = parser.parse_row(element)
         expected = [
-            {'column': 1, 'row': 1, 'data_type': 'n', 'value': 1, 'style_id': 0},
-            {'column': 4, 'row': 1, 'data_type': 'n', 'value': 2, 'style_id': 0},
-            {'column': 5, 'row': 1, 'data_type': 'n', 'value': 3, 'style_id': 0},
-            {'column': 7, 'row': 1, 'data_type': 'n', 'value': 4, 'style_id': 0},
+            (1, 1, 1, 'n', 0),
+            (1, 4, 2, 'n', 0),
+            (1, 5, 3, 'n', 0),
+            (1, 7, 4, 'n', 0),
         ]
         assert len(cells) == len(expected)
         for expected_cell, cell in zip(expected, cells):
@@ -662,7 +651,7 @@ class TestWorksheetParser:
         parser.parse_row(element)
         max_row, cells = parser.parse_row(element)
         expected = [
-            {'column': 1, 'row': 2, 'data_type': 'n', 'value': 2, 'style_id': 0},
+            (2, 1, 2, 'n', 0),
         ]
         for expected_cell, cell in zip(expected, cells):
             assert expected_cell == cell


### PR DESCRIPTION
## Summary
- **Eliminate intermediate dict** in `parse_cell` — returns a `(row, column, value, data_type, style_id)` tuple instead of a dict, removing 1 dict allocation + 5 key insertions per cell
- **Bypass `Cell.__init__`** in `bind_cells` — uses `__new__` + direct slot assignment, eliminating `super().__init__()` overhead, keyword argument dispatch, and redundant default assignments per cell
- **Local variable caching** in `bind_cells` hot loop (`_Cell`, `_new`, `_StyleArray`, `_cell_styles`, `_ws`, `_cells`) to avoid repeated attribute lookups
- **Update read-only path** in `_get_row` to unpack tuples instead of dict key lookups

## Benchmark (260K cells, 5 sheets × 2000 rows × 26 cols)

| Benchmark | Before (s) | After (s) | Change |
|---|---|---|---|
| `load_scaled` | 5.89 | 5.87 | -0.3% |
| `read_only_iter` | 5.29 | 5.01 | **-5.3%** |
| `cell_construction_50k` | 0.072 | 0.064 | **-11%** |

At 260K cells, XML parsing dominates. The issue reports 15.7M cells where `bind_cells` alone was 79s — these optimizations eliminate per-cell dict creation, key lookups, and `__init__` overhead that scale linearly with cell count.

Closes #6

## Test plan
- [x] All 2736 existing tests pass
- [ ] Verify load/save round-trip on real-world workbooks
- [ ] Profile with large workbook to confirm `bind_cells` overhead reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)