### PR TITLE
perf: optimize IndexedList.add and StyleArray.__hash__

### DIFF
--- a/fastpyxl/styles/cell_style.py
+++ b/fastpyxl/styles/cell_style.py
@@ -30,7 +30,7 @@ class StyleArray(array):
     Simplified named tuple with an array
     """
 
-    __slots__ = ()
+    __slots__ = ('_hash',)
     tagname = 'xf'
 
     fontId = ArrayDescriptor(0)
@@ -45,11 +45,22 @@ class StyleArray(array):
 
 
     def __new__(cls, args=[0]*9):
-        return array.__new__(cls, 'i', args)
+        obj = array.__new__(cls, 'i', args)
+        obj._hash = None
+        return obj
+
+
+    def __setitem__(self, index, value):
+        self._hash = None
+        array.__setitem__(self, index, value)
 
 
     def __hash__(self):
-        return hash(tuple(self))
+        h = self._hash
+        if h is None:
+            h = hash(tuple(self))
+            self._hash = h
+        return h
 
 
     def __copy__(self):

--- a/fastpyxl/utils/indexed_list.py
+++ b/fastpyxl/utils/indexed_list.py
@@ -45,5 +45,10 @@ class IndexedList(list):
             list.append(self, value)
 
     def add(self, value):
-        self.append(value)
-        return self._dict[value]
+        d = self._dict
+        idx = d.get(value)
+        if idx is None:
+            idx = len(self)
+            d[value] = idx
+            list.append(self, value)
+        return idx


### PR DESCRIPTION
## Summary
- **Cache `StyleArray.__hash__`**: Uses a sentinel-based approach — hash is computed once and cached in a `_hash` slot, invalidated on `__setitem__` mutation. Eliminates redundant `tuple()` + `hash()` calls when the same StyleArray is hashed repeatedly (e.g., during save deduplication).
- **Inline `IndexedList.add`**: Replaces the `append()` delegation + second dict lookup with a single `dict.get()` call, cutting dict operations from 2–3 to 1 per call.

## Benchmark results (median, 5 sheets × 2000 rows × 26 cols)

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| `save_styled` | 7.952s | 6.843s | **-13.9%** |
| `indexed_list_add_50k` | 0.095s | 0.074s | **-21.8%** |
| `save_scaled` | 3.237s | 3.290s | ~flat |

Closes #9

## Test plan
- [x] All 2736 tests pass, 9 skipped
- [x] Verify benchmark improvements on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)