### PR TITLE
perf: defer StyleArray allocation on load by storing style_id

### DIFF
--- a/fastpyxl/styles/styleable.py
+++ b/fastpyxl/styles/styleable.py
@@ -123,8 +123,7 @@ class NamedStyleDescriptor:
 
 
     def __set__(self, instance, value):
-        if not instance._style:
-            instance._style = StyleArray()
+        instance._ensure_style_array()
         wb = instance.parent.parent
         coll = self._get_collection(wb)
         pending_styles = instance._pending_styles
@@ -169,8 +168,7 @@ class NamedStyleDescriptor:
             if isinstance(pending, NamedStyle):
                 return pending.name
             return pending
-        if not instance._style:
-            instance._style = StyleArray()
+        instance._ensure_style_array()
         idx = instance._style[self._key_idx]
         coll = self._get_collection(instance.parent.parent)
         return coll.names[idx]
@@ -183,14 +181,15 @@ class StyleArrayDescriptor:
         self._key_idx = _STYLE_KEY_INDEX[key]
 
     def __set__(self, instance, value):
-        if instance._style is None:
-            instance._style = StyleArray()
+        instance._ensure_style_array()
         instance._style[self._key_idx] = value
 
 
     def __get__(self, instance, cls):
         if instance._style is None:
-            return False
+            if not instance._style_id:
+                return False
+            instance._ensure_style_array()
         return bool(instance._style[self._key_idx])
 
 
@@ -209,19 +208,24 @@ class StyleableObject:
     quotePrefix = StyleArrayDescriptor('quotePrefix')
     pivotButton = StyleArrayDescriptor('pivotButton')
 
-    __slots__ = ('parent', '_style', '_pending_styles', '_pending_named_style')
+    __slots__ = ('parent', '_style', '_style_id', '_pending_styles', '_pending_named_style')
 
     def __init__(self, sheet, style_array=None):
         self.parent = sheet
         if style_array is not None:
             style_array = StyleArray(style_array)
         self._style = style_array
+        self._style_id = 0
         self._pending_styles = {}
         self._pending_named_style = None
 
     def _ensure_style_array(self):
         if self._style is None:
-            self._style = StyleArray()
+            style_id = self._style_id
+            if style_id:
+                self._style = StyleArray(self.parent.parent._cell_styles[style_id])
+            else:
+                self._style = StyleArray()
 
     def _apply_pending_named_style(self):
         pending = self._pending_named_style
@@ -271,6 +275,8 @@ class StyleableObject:
 
     @property
     def style_id(self):
+        if self._style is None and self._style_id and not self._pending_styles and self._pending_named_style is None:
+            return self._style_id
         self._ensure_style_array()
         self._apply_pending_named_style()
         self._apply_pending_styles()
@@ -284,5 +290,5 @@ class StyleableObject:
         if self._pending_styles:
             return True
         if self._style is None:
-            return False
+            return self._style_id != 0
         return any(self._style)

--- a/fastpyxl/worksheet/_reader.py
+++ b/fastpyxl/worksheet/_reader.py
@@ -9,7 +9,6 @@ from fastpyxl.xml.functions import iterparse
 
 # package imports
 from fastpyxl.cell import Cell, MergedCell
-from fastpyxl.styles.cell_style import StyleArray
 from fastpyxl.cell.text import Text
 from fastpyxl.worksheet.dimensions import (
     ColumnDimension,
@@ -370,15 +369,14 @@ class WorksheetReader:
     def bind_cells(self):
         _Cell = Cell
         _new = _Cell.__new__
-        _StyleArray = StyleArray
-        _cell_styles = self.ws.parent._cell_styles
         _ws = self.ws
         _cells = _ws._cells
         for idx, row in self.parser.parse():
             for cell_row, cell_col, cell_val, cell_dt, cell_sid in row:
                 c = _new(_Cell)
                 c.parent = _ws
-                c._style = _StyleArray(_cell_styles[cell_sid])
+                c._style = None
+                c._style_id = cell_sid
                 c._pending_styles = {}
                 c._pending_named_style = None
                 c.row = cell_row

--- a/fastpyxl/worksheet/copier.py
+++ b/fastpyxl/worksheet/copier.py
@@ -53,6 +53,7 @@ class WorksheetCopy:
 
             if source_cell.has_style:
                 target_cell._style = copy(source_cell._style)
+                target_cell._style_id = source_cell._style_id
 
             sp = source_cell._pending_styles
             if sp:


### PR DESCRIPTION
## Summary
- **Defers `StyleArray` creation** during workbook load by storing the integer `style_id` instead of allocating a `StyleArray` copy per cell — eliminates the second-largest per-cell cost on load
- **Short-circuits `style_id` property** for unmodified loaded cells, returning the stored id directly without materializing the `StyleArray` or calling `_cell_styles.add()`
- Updates all style descriptors (`NamedStyleDescriptor`, `StyleArrayDescriptor`) and the worksheet copier to correctly handle the deferred state

## Benchmark results

| Benchmark | Before | After | Change |
|---|---|---|---|
| `load_scaled_5s_2000r_26c` | 5.358s | 5.090s | **-5.0%** |
| `save_scaled_5s_2000r_26c` | 3.336s | 3.306s | -0.9% |
| `save_styled_5s_2000r_26c` | 6.702s | 6.667s | -0.5% |
| `style_id_materialization_10k` | 0.195s | 0.153s | **-21.2%** |

Closes #7

## Test plan
- [x] All 2736 existing tests pass (9 skipped)
- [x] Verify load/save roundtrip preserves cell styles on a real workbook (tested with 86-sheet World Bank XLSM — 531 styled cells, 0 value mismatches)
- [x] Verify worksheet copy preserves deferred style state (300 cells compared, 0 mismatches)
- [x] Verify style modification after load correctly materializes and updates (modified font on styled cell, roundtripped, confirmed persistence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)