### PR TITLE
fix: use valid ReadTheDocs OS version in config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-lts-latest
+  os: ubuntu-24.04
   tools:
     python: "3.12"
     # You can also specify other tool versions:


### PR DESCRIPTION
## Summary
- Replace `ubuntu-lts-latest` with `ubuntu-24.04` in `.readthedocs.yaml` so RTD builds succeed

## Test plan
- [ ] Verify ReadTheDocs build triggers and completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)