### PR TITLE
docs: rebrand documentation from openpyxl to fastpyxl

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -1,17 +1,28 @@
+Changelog
+=========
+
+The following changelog is inherited from
+`openpyxl <https://pypi.org/project/openpyxl/>`_, from which fastpyxl was
+forked. Issue and PR links refer to the original openpyxl repositories.
+
+For fastpyxl-specific changes, see the
+`GitHub releases <https://github.com/Promptly-Technologies-LLC/fastpyxl/releases>`_.
+
+
 3.1.5 (2024-06-28)
-==================
+------------------
 
 
-* `#2187 <https://github.com/fastpyxl/fastpyxl/issues/2187>`_ Test fails due to change in Numpy API
-* `#2198 <https://github.com/fastpyxl/fastpyxl/issues/2198>`_ Excel is very fussy about the version number
-* `#2200 <https://github.com/fastpyxl/fastpyxl/issues/2200>`_ Poor perfomance when reading workbooks with lots of named styles
+* `#2187 <https://github.com/openpyxl/openpyxl/issues/2187>`_ Test fails due to change in Numpy API
+* `#2198 <https://github.com/openpyxl/openpyxl/issues/2198>`_ Excel is very fussy about the version number
+* `#2200 <https://github.com/openpyxl/openpyxl/issues/2200>`_ Poor perfomance when reading workbooks with lots of named styles
 
 
 3.1.4 (2024-06-12)
-==================
+------------------
 
-* `#2189 <https://github.com/fastpyxl/fastpyxl/issues/2189>`_ Assigning named styles doesn't work
-* `#2190 <https://github.com/fastpyxl/fastpyxl/issues/2190>`_ Problems caused when saving workbooks created by LibreOffice
+* `#2189 <https://github.com/openpyxl/openpyxl/issues/2189>`_ Assigning named styles doesn't work
+* `#2190 <https://github.com/openpyxl/openpyxl/issues/2190>`_ Problems caused when saving workbooks created by LibreOffice
 
 
 Changes
@@ -21,28 +32,28 @@ Changes
 
 
 3.1.3 (2024-05-29)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#1401 <https://github.com/fastpyxl/fastpyxl/issues/1401>`_ Column name caches are slow and use a lot of memory
-* `#1457 <https://github.com/fastpyxl/fastpyxl/issues/1457>`_ Improved handling of duplicate named styles
-* `#1842 <https://github.com/fastpyxl/fastpyxl/issues/1842>`_ Rich-text can be saved if lxml is not installed
-* `#1954 <https://github.com/fastpyxl/fastpyxl/issues/1954>`_ Documentation for sheet views is incorrect
-* `#1973 <https://github.com/fastpyxl/fastpyxl/issues/1973>`_ Timedeltas not read properly in read-only mode
-* `#1987 <https://github.com/fastpyxl/fastpyxl/issues/1987>`_ List of formulae names contains mistakes
-* `#1967 <https://github.com/fastpyxl/fastpyxl/issues/1967>`_ Filters does not handle non-numerical filters
-* `#2054 <https://github.com/fastpyxl/fastpyxl/issues/2054>`_ Type checking increases exponentially
-* `#2057 <https://github.com/fastpyxl/fastpyxl/issues/2057>`_ Loading pivot tables can be unnecessarily slow
-* `#2102 <https://github.com/fastpyxl/fastpyxl/issues/2102>`_ Improve performance when reading files with lots of custom properties
-* `#2106 <https://github.com/fastpyxl/fastpyxl/issues/2106>`_ Setting Trendline.name attribute raises exception when saving
-* `#2120 <https://github.com/fastpyxl/fastpyxl/issues/2120>`_ Timezone and Zombie formatting cannot be combined.
-* `#2107 <https://github.com/fastpyxl/fastpyxl/issues/2107>`_ Column name generation is inefficient and slow
-* `#2122 <https://github.com/fastpyxl/fastpyxl/issues/2122>`_ File handlers not always released in read-only mode
-* `#2149 <https://github.com/fastpyxl/fastpyxl/issues/2149>`_ Workbook files not properly closed on Python ≥ 3.11.8 and Windows
-* `#2161 <https://github.com/fastpyxl/fastpyxl/issues/2161>`_ Pivot cache definitions using tupleCache had serialisation issues
+* `#1401 <https://github.com/openpyxl/openpyxl/issues/1401>`_ Column name caches are slow and use a lot of memory
+* `#1457 <https://github.com/openpyxl/openpyxl/issues/1457>`_ Improved handling of duplicate named styles
+* `#1842 <https://github.com/openpyxl/openpyxl/issues/1842>`_ Rich-text can be saved if lxml is not installed
+* `#1954 <https://github.com/openpyxl/openpyxl/issues/1954>`_ Documentation for sheet views is incorrect
+* `#1973 <https://github.com/openpyxl/openpyxl/issues/1973>`_ Timedeltas not read properly in read-only mode
+* `#1987 <https://github.com/openpyxl/openpyxl/issues/1987>`_ List of formulae names contains mistakes
+* `#1967 <https://github.com/openpyxl/openpyxl/issues/1967>`_ Filters does not handle non-numerical filters
+* `#2054 <https://github.com/openpyxl/openpyxl/issues/2054>`_ Type checking increases exponentially
+* `#2057 <https://github.com/openpyxl/openpyxl/issues/2057>`_ Loading pivot tables can be unnecessarily slow
+* `#2102 <https://github.com/openpyxl/openpyxl/issues/2102>`_ Improve performance when reading files with lots of custom properties
+* `#2106 <https://github.com/openpyxl/openpyxl/issues/2106>`_ Setting Trendline.name attribute raises exception when saving
+* `#2120 <https://github.com/openpyxl/openpyxl/issues/2120>`_ Timezone and Zombie formatting cannot be combined.
+* `#2107 <https://github.com/openpyxl/openpyxl/issues/2107>`_ Column name generation is inefficient and slow
+* `#2122 <https://github.com/openpyxl/openpyxl/issues/2122>`_ File handlers not always released in read-only mode
+* `#2149 <https://github.com/openpyxl/openpyxl/issues/2149>`_ Workbook files not properly closed on Python ≥ 3.11.8 and Windows
+* `#2161 <https://github.com/openpyxl/openpyxl/issues/2161>`_ Pivot cache definitions using tupleCache had serialisation issues
 
 Changes
 -------
@@ -51,27 +62,27 @@ Changes
 
 
 3.1.2 (2023-03-11)
-==================
+------------------
 
-* `#1963 <https://github.com/fastpyxl/fastpyxl/issues/1963>`_ Cannot read worksheets in read-only mode with locally scoped definitions
-* `#1974 <https://github.com/fastpyxl/fastpyxl/issues/1974>`_ Empty custom properties cause invalid files
+* `#1963 <https://github.com/openpyxl/openpyxl/issues/1963>`_ Cannot read worksheets in read-only mode with locally scoped definitions
+* `#1974 <https://github.com/openpyxl/openpyxl/issues/1974>`_ Empty custom properties cause invalid files
 
 
 
 
 3.1.1 (2023-02-13)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#1881 <https://github.com/fastpyxl/fastpyxl/issues/1881>`_ DocumentProperties times set by module import only
-* `#1947 <https://github.com/fastpyxl/fastpyxl/issues/1947>`_ Worksheet-specific definitions are missing
+* `#1881 <https://github.com/openpyxl/openpyxl/issues/1881>`_ DocumentProperties times set by module import only
+* `#1947 <https://github.com/openpyxl/openpyxl/issues/1947>`_ Worksheet-specific definitions are missing
 
 
 3.1.0 (2023-01-31)
-==================
+------------------
 
 
 New Features
@@ -84,29 +95,29 @@ New Features
 Bugfixes
 --------
 
-* `#1156 <https://github.com/fastpyxl/fastpyxl/issues/1156>`_ Table filters are always overriden
-* `#1360 <https://github.com/fastpyxl/fastpyxl/issues/1360>`_ Can't read some ScatterCharts if n
-* `#1724 <https://github.com/fastpyxl/fastpyxl/issues/1724>`_ Problem with multilevel indices in dataframes
-* `#1763 <https://github.com/fastpyxl/fastpyxl/issues/1763>`_ Make calculating worksheet sizes slightly faster
-* `#1772 <https://github.com/fastpyxl/fastpyxl/issues/1772>`_ Problem with category indices in dataframes
-* `#1786 <https://github.com/fastpyxl/fastpyxl/issues/1786>`_ NamedStyles share attributes - mutables gotcha
-* `#1851 <https://github.com/fastpyxl/fastpyxl/issues/1851>`_ Allow print area to be set to None
-* `#1852 <https://github.com/fastpyxl/fastpyxl/issues/1852>`_ Worksheet for print title and print areas can't be found
-* `#1853 <https://github.com/fastpyxl/fastpyxl/issues/1853>`_ Custom document properties that are strings can be empty
-* `#1858 <https://github.com/fastpyxl/fastpyxl/issues/1858>`_ ConditionalFormatting lost when pivot table updated
-* `#1864 <https://github.com/fastpyxl/fastpyxl/issues/1864>`_ Better handling of defined names
-* `#1904 <https://github.com/fastpyxl/fastpyxl/issues/1904>`_ dataframe_to_rows() misalignment on multiindex
-* `#1908 <https://github.com/fastpyxl/fastpyxl/issues/1908>`_ Ditto
-* `#1912 <https://github.com/fastpyxl/fastpyxl/issues/1912>`_ Excel doesn't like xmlns:space on nodes with only whitespace, which it treats as empty.
-* `#1942 <https://github.com/fastpyxl/fastpyxl/issues/1942>`_ Exception when print areas use table references.
+* `#1156 <https://github.com/openpyxl/openpyxl/issues/1156>`_ Table filters are always overriden
+* `#1360 <https://github.com/openpyxl/openpyxl/issues/1360>`_ Can't read some ScatterCharts if n
+* `#1724 <https://github.com/openpyxl/openpyxl/issues/1724>`_ Problem with multilevel indices in dataframes
+* `#1763 <https://github.com/openpyxl/openpyxl/issues/1763>`_ Make calculating worksheet sizes slightly faster
+* `#1772 <https://github.com/openpyxl/openpyxl/issues/1772>`_ Problem with category indices in dataframes
+* `#1786 <https://github.com/openpyxl/openpyxl/issues/1786>`_ NamedStyles share attributes - mutables gotcha
+* `#1851 <https://github.com/openpyxl/openpyxl/issues/1851>`_ Allow print area to be set to None
+* `#1852 <https://github.com/openpyxl/openpyxl/issues/1852>`_ Worksheet for print title and print areas can't be found
+* `#1853 <https://github.com/openpyxl/openpyxl/issues/1853>`_ Custom document properties that are strings can be empty
+* `#1858 <https://github.com/openpyxl/openpyxl/issues/1858>`_ ConditionalFormatting lost when pivot table updated
+* `#1864 <https://github.com/openpyxl/openpyxl/issues/1864>`_ Better handling of defined names
+* `#1904 <https://github.com/openpyxl/openpyxl/issues/1904>`_ dataframe_to_rows() misalignment on multiindex
+* `#1908 <https://github.com/openpyxl/openpyxl/issues/1908>`_ Ditto
+* `#1912 <https://github.com/openpyxl/openpyxl/issues/1912>`_ Excel doesn't like xmlns:space on nodes with only whitespace, which it treats as empty.
+* `#1942 <https://github.com/openpyxl/openpyxl/issues/1942>`_ Exception when print areas use table references.
 
 
 Pull Requests
 -------------
 
-* `PR409 <https://github.com/fastpyxl/fastpyxl/pull/409/>`_ Support for Rich Text in cells
-* `PR411 <https://github.com/fastpyxl/fastpyxl/pull/411/>`_ Provide more information when workbook cannot be loaded
-* `PR407 <https://github.com/fastpyxl/fastpyxl/pull/407/>`_ Support for Custom Document Properties
+* `PR409 <https://github.com/openpyxl/openpyxl/pull/409/>`_ Support for Rich Text in cells
+* `PR411 <https://github.com/openpyxl/openpyxl/pull/411/>`_ Provide more information when workbook cannot be loaded
+* `PR407 <https://github.com/openpyxl/openpyxl/pull/407/>`_ Support for Custom Document Properties
 
 
 Deprecations
@@ -122,186 +133,186 @@ The following deprecated methods have been removed from workbooks: get_named_ran
 
 
 3.0.10 (2022-05-19)
-===================
+-------------------
 
 
 Bugfixes
 --------
 
-* `#1684 <https://github.com/fastpyxl/fastpyxl/issues/1684>`_ Image files not closed when workbooks are saved
-* `#1778 <https://github.com/fastpyxl/fastpyxl/issues/1778>`_ Problem with missing scope attribute in Pivot Table formats
-* `#1821 <https://github.com/fastpyxl/fastpyxl/issues/1821>`_ Excel unhappy when multiple sorts are defined
-* `#2014 <https://github.com/fastpyxl/fastpyxl/issues/2014>`_ Accounting format interpreted as datetime
+* `#1684 <https://github.com/openpyxl/openpyxl/issues/1684>`_ Image files not closed when workbooks are saved
+* `#1778 <https://github.com/openpyxl/openpyxl/issues/1778>`_ Problem with missing scope attribute in Pivot Table formats
+* `#1821 <https://github.com/openpyxl/openpyxl/issues/1821>`_ Excel unhappy when multiple sorts are defined
+* `#2014 <https://github.com/openpyxl/openpyxl/issues/2014>`_ Accounting format interpreted as datetime
 
 
 3.0.9 (2021-09-22)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#1284 <https://github.com/fastpyxl/fastpyxl/issues/1284>`_ Ignore blank ignored in existing Data Validations
-* `#1539 <https://github.com/fastpyxl/fastpyxl/issues/1539>`_ Add support for cell protection for merged cell ranges
-* `#1645 <https://github.com/fastpyxl/fastpyxl/issues/1645>`_ Timezone-aware datetimes raise an Exception
-* `#1666 <https://github.com/fastpyxl/fastpyxl/issues/1666>`_ Improved normalisation of chart series
-* `#1670 <https://github.com/fastpyxl/fastpyxl/issues/1670>`_ Catch OverflowError for out of range datetimes
-* `#1708 <https://github.com/fastpyxl/fastpyxl/issues/1708>`_ Alignment.relativeIndent can be negative
-* `#1736 <https://github.com/fastpyxl/fastpyxl/issues/1769>`_ Incorrect default value `groupBy` attribute
+* `#1284 <https://github.com/openpyxl/openpyxl/issues/1284>`_ Ignore blank ignored in existing Data Validations
+* `#1539 <https://github.com/openpyxl/openpyxl/issues/1539>`_ Add support for cell protection for merged cell ranges
+* `#1645 <https://github.com/openpyxl/openpyxl/issues/1645>`_ Timezone-aware datetimes raise an Exception
+* `#1666 <https://github.com/openpyxl/openpyxl/issues/1666>`_ Improved normalisation of chart series
+* `#1670 <https://github.com/openpyxl/openpyxl/issues/1670>`_ Catch OverflowError for out of range datetimes
+* `#1708 <https://github.com/openpyxl/openpyxl/issues/1708>`_ Alignment.relativeIndent can be negative
+* `#1736 <https://github.com/openpyxl/openpyxl/issues/1769>`_ Incorrect default value `groupBy` attribute
 
 
 3.0.8 (brown bag)
-==================
+------------------
 
 Deleted because it contained breaking changes from 3.1
 
 
 3.0.7 (2021-03-09)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#1510 <https://github.com/fastpyxl/fastpyxl/issues/1510>`_ Problems with zero time values
-* `#1588 <https://github.com/fastpyxl/fastpyxl/issues/1588>`_ Not possible to correctly convert excel dates to timedelta
-* `#1589 <https://github.com/fastpyxl/fastpyxl/issues/1589>`_ Exception raised when merging cells which do not have borders all the way round.
-* `#1594 <https://github.com/fastpyxl/fastpyxl/issues/1594>`_ Python 2 print statement in the tutorial
+* `#1510 <https://github.com/openpyxl/openpyxl/issues/1510>`_ Problems with zero time values
+* `#1588 <https://github.com/openpyxl/openpyxl/issues/1588>`_ Not possible to correctly convert excel dates to timedelta
+* `#1589 <https://github.com/openpyxl/openpyxl/issues/1589>`_ Exception raised when merging cells which do not have borders all the way round.
+* `#1594 <https://github.com/openpyxl/openpyxl/issues/1594>`_ Python 2 print statement in the tutorial
 
 
 Pull Requests
 -------------
 
-* `PR392 <https://github.com/fastpyxl/fastpyxl/pull/392/>`_ Add documentation on datetime handling
-* `PR393 <https://github.com/fastpyxl/fastpyxl/pull/393/>`_ Drop dependency on jdcal
-* `PR394 <https://github.com/fastpyxl/fastpyxl/pull/394/>`_ Datetime rounding
-* `PR395 <https://github.com/fastpyxl/fastpyxl/pull/395/>`_ Unify handling of 1900 epoch
-* `PR397 <https://github.com/fastpyxl/fastpyxl/pull/397/>`_ Add explicit support for reading datetime deltas
-* `PR399 <https://github.com/fastpyxl/fastpyxl/pull/399/>`_ Millisecond precision for datetimes
+* `PR392 <https://github.com/openpyxl/openpyxl/pull/392/>`_ Add documentation on datetime handling
+* `PR393 <https://github.com/openpyxl/openpyxl/pull/393/>`_ Drop dependency on jdcal
+* `PR394 <https://github.com/openpyxl/openpyxl/pull/394/>`_ Datetime rounding
+* `PR395 <https://github.com/openpyxl/openpyxl/pull/395/>`_ Unify handling of 1900 epoch
+* `PR397 <https://github.com/openpyxl/openpyxl/pull/397/>`_ Add explicit support for reading datetime deltas
+* `PR399 <https://github.com/openpyxl/openpyxl/pull/399/>`_ Millisecond precision for datetimes
 
 
 3.0.6 (2021-01-14)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#1154 <https://github.com/fastpyxl/fastpyxl/issues/1154>`_ Borders in differential styles are incorrect
-* `#1287 <https://github.com/fastpyxl/fastpyxl/issues/1528>`_ Error when opening some pivot tables
-* `#1366 <https://github.com/fastpyxl/fastpyxl/issues/1366>`_ Resave breaks the border format in conditional formatting rules
-* `#1450 <https://github.com/fastpyxl/fastpyxl/issues/1450>`_ Read-only workbook not closed properly if generator interrupted
-* `#1547 <https://github.com/fastpyxl/fastpyxl/issues/1547>`_ Pandas.Multiindex.labels deprecated
-* `#1552 <https://github.com/fastpyxl/fastpyxl/issues/1557>`_ Pandas.Multiinex not expanded correctly
-* `#1557 <https://github.com/fastpyxl/fastpyxl/issues/1557>`_ Cannot read rows with exponents
-* `#1568 <https://github.com/fastpyxl/fastpyxl/issues/1568>`_ numpy.float is deprecated
-* `#1571 <https://github.com/fastpyxl/fastpyxl/issues/1571>`_ Cells without coordinate attributes not always correctly handled
+* `#1154 <https://github.com/openpyxl/openpyxl/issues/1154>`_ Borders in differential styles are incorrect
+* `#1287 <https://github.com/openpyxl/openpyxl/issues/1528>`_ Error when opening some pivot tables
+* `#1366 <https://github.com/openpyxl/openpyxl/issues/1366>`_ Resave breaks the border format in conditional formatting rules
+* `#1450 <https://github.com/openpyxl/openpyxl/issues/1450>`_ Read-only workbook not closed properly if generator interrupted
+* `#1547 <https://github.com/openpyxl/openpyxl/issues/1547>`_ Pandas.Multiindex.labels deprecated
+* `#1552 <https://github.com/openpyxl/openpyxl/issues/1557>`_ Pandas.Multiinex not expanded correctly
+* `#1557 <https://github.com/openpyxl/openpyxl/issues/1557>`_ Cannot read rows with exponents
+* `#1568 <https://github.com/openpyxl/openpyxl/issues/1568>`_ numpy.float is deprecated
+* `#1571 <https://github.com/openpyxl/openpyxl/issues/1571>`_ Cells without coordinate attributes not always correctly handled
 
 
 Pull Requests
 -------------
 
-* `PR385 <https://github.com/fastpyxl/fastpyxl/pull/385/>`_ Improved handling of borders for differential styles
-* `PR386 <https://github.com/fastpyxl/fastpyxl/pull/386/>`_ Support subclasses of datetime objects
-* `PR387 <https://github.com/fastpyxl/fastpyxl/pull/387/>`_ Improved handling of cells without coordinates
+* `PR385 <https://github.com/openpyxl/openpyxl/pull/385/>`_ Improved handling of borders for differential styles
+* `PR386 <https://github.com/openpyxl/openpyxl/pull/386/>`_ Support subclasses of datetime objects
+* `PR387 <https://github.com/openpyxl/openpyxl/pull/387/>`_ Improved handling of cells without coordinates
 
 
 3.0.5 (2020-08-21)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#1413 <https://github.com/fastpyxl/fastpyxl/issues/1413>`_ Incorrectly consider currency format as datetime
-* `#1490 <https://github.com/fastpyxl/fastpyxl/issues/1490>`_ Cannot copy worksheets with merged cells
-* `#1492 <https://github.com/fastpyxl/fastpyxl/issues/1492>`_ Empty worksheets do not return generators when looping.
-* `#1496 <https://github.com/fastpyxl/fastpyxl/issues/1496>`_ Hyperlinks duplicated on multiple saves
-* `#1500 <https://github.com/fastpyxl/fastpyxl/issues/1500>`_ Incorrectly literal format as datetime
-* `#1502 <https://github.com/fastpyxl/fastpyxl/issues/1502>`_ Links set to range of cells not preserved
-* `#1507 <https://github.com/fastpyxl/fastpyxl/issues/1507>`_ Exception when opening workbook with chartsheets and tables
+* `#1413 <https://github.com/openpyxl/openpyxl/issues/1413>`_ Incorrectly consider currency format as datetime
+* `#1490 <https://github.com/openpyxl/openpyxl/issues/1490>`_ Cannot copy worksheets with merged cells
+* `#1492 <https://github.com/openpyxl/openpyxl/issues/1492>`_ Empty worksheets do not return generators when looping.
+* `#1496 <https://github.com/openpyxl/openpyxl/issues/1496>`_ Hyperlinks duplicated on multiple saves
+* `#1500 <https://github.com/openpyxl/openpyxl/issues/1500>`_ Incorrectly literal format as datetime
+* `#1502 <https://github.com/openpyxl/openpyxl/issues/1502>`_ Links set to range of cells not preserved
+* `#1507 <https://github.com/openpyxl/openpyxl/issues/1507>`_ Exception when opening workbook with chartsheets and tables
 
 
 3.0.4 (2020-06-24)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#844 <https://github.com/fastpyxl/fastpyxl/issues/844>`_ Find tables by name
-* `#1414 <https://github.com/fastpyxl/fastpyxl/issues/1414>`_ Worksheet protection missing in existing files
-* `#1439 <https://github.com/fastpyxl/fastpyxl/issues/1439>`_ Exception when reading files with external images
-* `#1452 <https://github.com/fastpyxl/fastpyxl/issues/1452>`_ Reading lots of merged cells is very slow.
-* `#1455 <https://github.com/fastpyxl/fastpyxl/issues/1455>`_ Read support for Bubble Charts.
-* `#1458 <https://github.com/fastpyxl/fastpyxl/issues/1458>`_ Preserve any indexed colours
-* `#1473 <https://github.com/fastpyxl/fastpyxl/issues/1473>`_ Reading many thousand of merged cells is really slow.
-* `#1474 <https://github.com/fastpyxl/fastpyxl/issues/1474>`_ Adding tables in write-only mode raises an exception.
+* `#844 <https://github.com/openpyxl/openpyxl/issues/844>`_ Find tables by name
+* `#1414 <https://github.com/openpyxl/openpyxl/issues/1414>`_ Worksheet protection missing in existing files
+* `#1439 <https://github.com/openpyxl/openpyxl/issues/1439>`_ Exception when reading files with external images
+* `#1452 <https://github.com/openpyxl/openpyxl/issues/1452>`_ Reading lots of merged cells is very slow.
+* `#1455 <https://github.com/openpyxl/openpyxl/issues/1455>`_ Read support for Bubble Charts.
+* `#1458 <https://github.com/openpyxl/openpyxl/issues/1458>`_ Preserve any indexed colours
+* `#1473 <https://github.com/openpyxl/openpyxl/issues/1473>`_ Reading many thousand of merged cells is really slow.
+* `#1474 <https://github.com/openpyxl/openpyxl/issues/1474>`_ Adding tables in write-only mode raises an exception.
 
 
 Pull Requests
 -------------
 
-* `PR377 <https://github.com/fastpyxl/fastpyxl/pull/377/>`_ Add support for finding tables by name or range.
+* `PR377 <https://github.com/openpyxl/openpyxl/pull/377/>`_ Add support for finding tables by name or range.
 
 
 3.0.3 (2020-01-20)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#1260 <https://github.com/fastpyxl/fastpyxl/issues/1260>`_ Exception when handling merged cells with hyperlinks
-* `#1373 <https://github.com/fastpyxl/fastpyxl/issues/1373>`_ Problems when both lxml and defusedxml are installed
-* `#1385 <https://github.com/fastpyxl/fastpyxl/issues/1385>`_ CFVO with incorrect values cannot be processed
+* `#1260 <https://github.com/openpyxl/openpyxl/issues/1260>`_ Exception when handling merged cells with hyperlinks
+* `#1373 <https://github.com/openpyxl/openpyxl/issues/1373>`_ Problems when both lxml and defusedxml are installed
+* `#1385 <https://github.com/openpyxl/openpyxl/issues/1385>`_ CFVO with incorrect values cannot be processed
 
 
 3.0.2 (2019-11-25)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#1267 <https://github.com/fastpyxl/fastpyxl/issues/1267>`_ DeprecationError if both defusedxml and lxml are installed
-* `#1345 <https://github.com/fastpyxl/fastpyxl/issues/1345>`_ ws._current_row is higher than ws.max_row
-* `#1365 <https://github.com/fastpyxl/fastpyxl/issues/1365>`_ Border bottom style is not optional when it should be
-* `#1367 <https://github.com/fastpyxl/fastpyxl/issues/1367>`_ Empty cells in read-only, values-only mode are sometimes returned as ReadOnlyCells
-* `#1368 <https://github.com/fastpyxl/fastpyxl/issues/1368>`_ Cannot add page breaks to existing worksheets if none exist already
+* `#1267 <https://github.com/openpyxl/openpyxl/issues/1267>`_ DeprecationError if both defusedxml and lxml are installed
+* `#1345 <https://github.com/openpyxl/openpyxl/issues/1345>`_ ws._current_row is higher than ws.max_row
+* `#1365 <https://github.com/openpyxl/openpyxl/issues/1365>`_ Border bottom style is not optional when it should be
+* `#1367 <https://github.com/openpyxl/openpyxl/issues/1367>`_ Empty cells in read-only, values-only mode are sometimes returned as ReadOnlyCells
+* `#1368 <https://github.com/openpyxl/openpyxl/issues/1368>`_ Cannot add page breaks to existing worksheets if none exist already
 
 
 Pull Requests
 -------------
 
-* `PR359 <https://github.com/fastpyxl/fastpyxl/pull/359/>`_ Improvements to the documentation
+* `PR359 <https://github.com/openpyxl/openpyxl/pull/359/>`_ Improvements to the documentation
 
 
 3.0.1 (2019-11-14)
-==================
+------------------
 
 Bugfixes
 --------
 
-* `#1250 <https://github.com/fastpyxl/fastpyxl/issues/1250>`_ Cannot read empty charts.
+* `#1250 <https://github.com/openpyxl/openpyxl/issues/1250>`_ Cannot read empty charts.
 
 
 Pull Requests
 -------------
 
-* `PR354 <https://github.com/fastpyxl/fastpyxl/pull/354/>`_ Fix for #1250
-* `PR352 <https://github.com/fastpyxl/fastpyxl/pull/354/>`_ TableStyleElement is a sequence
+* `PR354 <https://github.com/openpyxl/openpyxl/pull/354/>`_ Fix for #1250
+* `PR352 <https://github.com/openpyxl/openpyxl/pull/354/>`_ TableStyleElement is a sequence
 
 
 3.0.0 (2019-09-25)
-==================
+------------------
 
 Python 3.6+ only release
 ------------------------
 
 
 2.6.4 (2019-09-25)
-==================
+------------------
 
 
 Final release for Python 2.7 and 3.5
@@ -310,93 +321,93 @@ Final release for Python 2.7 and 3.5
 Bugfixes
 --------
 
-* ` #1330 <https://github.com/fastpyxl/fastpyxl/issues/1330>`_ Cannot save workbooks with comments more than once.
+* ` #1330 <https://github.com/openpyxl/openpyxl/issues/1330>`_ Cannot save workbooks with comments more than once.
 
 
 2.6.3 (2019-08-19)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#1237 <https://github.com/fastpyxl/fastpyxl/issues/1237>`_ Fix 3D charts.
-* `#1290 <https://github.com/fastpyxl/fastpyxl/issues/1290>`_ Minimum for holeSize in Doughnut charts too high
-* `#1291 <https://github.com/fastpyxl/fastpyxl/issues/1291>`_ Warning for MergedCells with comments
-* `#1296 <https://github.com/fastpyxl/fastpyxl/issues/1296>`_ Pagebreaks duplicated
-* `#1309 <https://github.com/fastpyxl/fastpyxl/issues/1309>`_ Workbook has no default CellStyle
-* `#1330 <https://github.com/fastpyxl/fastpyxl/issues/1330>`_ Workbooks with comments cannot be saved multiple times
+* `#1237 <https://github.com/openpyxl/openpyxl/issues/1237>`_ Fix 3D charts.
+* `#1290 <https://github.com/openpyxl/openpyxl/issues/1290>`_ Minimum for holeSize in Doughnut charts too high
+* `#1291 <https://github.com/openpyxl/openpyxl/issues/1291>`_ Warning for MergedCells with comments
+* `#1296 <https://github.com/openpyxl/openpyxl/issues/1296>`_ Pagebreaks duplicated
+* `#1309 <https://github.com/openpyxl/openpyxl/issues/1309>`_ Workbook has no default CellStyle
+* `#1330 <https://github.com/openpyxl/openpyxl/issues/1330>`_ Workbooks with comments cannot be saved multiple times
 
 
 Pull Requests
 -------------
 
-* `PR344 <https://github.com/fastpyxl/fastpyxl/pull/345/>`_ Make sure NamedStyles number formats are correctly handled
+* `PR344 <https://github.com/openpyxl/openpyxl/pull/345/>`_ Make sure NamedStyles number formats are correctly handled
 
 
 2.6.2 (2019-03-29)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#1173 <https://github.com/fastpyxl/fastpyxl/issues/1173>`_ Workbook has no _date_formats attribute
-* `#1190 <https://github.com/fastpyxl/fastpyxl/issues/1190>`_ Cannot create charts for worksheets with quotes in the title
-* `#1228 <https://github.com/fastpyxl/fastpyxl/issues/1228>`_ MergedCells not removed when range is unmerged
-* `#1232 <https://github.com/fastpyxl/fastpyxl/issues/1232>`_ Link to pivot table lost from charts
-* `#1233 <https://github.com/fastpyxl/fastpyxl/issues/1233>`_ Chart colours change after saving
-* `#1236 <https://github.com/fastpyxl/fastpyxl/issues/1236>`_ Cannot use ws.cell in read-only mode with Python 2.7
+* `#1173 <https://github.com/openpyxl/openpyxl/issues/1173>`_ Workbook has no _date_formats attribute
+* `#1190 <https://github.com/openpyxl/openpyxl/issues/1190>`_ Cannot create charts for worksheets with quotes in the title
+* `#1228 <https://github.com/openpyxl/openpyxl/issues/1228>`_ MergedCells not removed when range is unmerged
+* `#1232 <https://github.com/openpyxl/openpyxl/issues/1232>`_ Link to pivot table lost from charts
+* `#1233 <https://github.com/openpyxl/openpyxl/issues/1233>`_ Chart colours change after saving
+* `#1236 <https://github.com/openpyxl/openpyxl/issues/1236>`_ Cannot use ws.cell in read-only mode with Python 2.7
 
 
 
 2.6.1 (2019-03-04)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#1174 <https://github.com/fastpyxl/fastpyxl/issues/1174>`_ ReadOnlyCell.is_date does not work properly
-* `#1175 <https://github.com/fastpyxl/fastpyxl/issues/1175>`_ Cannot read Google Docs spreadsheet with a Pivot Table
-* `#1180 <https://github.com/fastpyxl/fastpyxl/issues/1180>`_ Charts created with fastpyxl cannot be styled
-* `#1181 <https://github.com/fastpyxl/fastpyxl/issues/1181>`_ Cannot handle some numpy number types
-* `#1182 <https://github.com/fastpyxl/fastpyxl/issues/1182>`_ Exception when reading unknowable number formats
-* `#1186 <https://github.com/fastpyxl/fastpyxl/issues/1186>`_ Only last formatting rule for a range loaded
-* `#1191 <https://github.com/fastpyxl/fastpyxl/issues/1191>`_ Give MergedCell a `value` attribute
-* `#1193 <https://github.com/fastpyxl/fastpyxl/issues/1193>`_ Cannot process worksheets with comments
-* `#1197 <https://github.com/fastpyxl/fastpyxl/issues/1197>`_ Cannot process worksheets with both row and page breaks
-* `#1204 <https://github.com/fastpyxl/fastpyxl/issues/1204>`_ Cannot reset dimensions in ReadOnlyWorksheets
-* `#1211 <https://github.com/fastpyxl/fastpyxl/issues/1211>`_ Incorrect descriptor in ParagraphProperties
-* `#1213 <https://github.com/fastpyxl/fastpyxl/issues/1213>`_ Missing `hier` attribute in PageField raises an exception
+* `#1174 <https://github.com/openpyxl/openpyxl/issues/1174>`_ ReadOnlyCell.is_date does not work properly
+* `#1175 <https://github.com/openpyxl/openpyxl/issues/1175>`_ Cannot read Google Docs spreadsheet with a Pivot Table
+* `#1180 <https://github.com/openpyxl/openpyxl/issues/1180>`_ Charts created with fastpyxl cannot be styled
+* `#1181 <https://github.com/openpyxl/openpyxl/issues/1181>`_ Cannot handle some numpy number types
+* `#1182 <https://github.com/openpyxl/openpyxl/issues/1182>`_ Exception when reading unknowable number formats
+* `#1186 <https://github.com/openpyxl/openpyxl/issues/1186>`_ Only last formatting rule for a range loaded
+* `#1191 <https://github.com/openpyxl/openpyxl/issues/1191>`_ Give MergedCell a `value` attribute
+* `#1193 <https://github.com/openpyxl/openpyxl/issues/1193>`_ Cannot process worksheets with comments
+* `#1197 <https://github.com/openpyxl/openpyxl/issues/1197>`_ Cannot process worksheets with both row and page breaks
+* `#1204 <https://github.com/openpyxl/openpyxl/issues/1204>`_ Cannot reset dimensions in ReadOnlyWorksheets
+* `#1211 <https://github.com/openpyxl/openpyxl/issues/1211>`_ Incorrect descriptor in ParagraphProperties
+* `#1213 <https://github.com/openpyxl/openpyxl/issues/1213>`_ Missing `hier` attribute in PageField raises an exception
 
 
 2.6.0 (2019-02-06)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#1162 <https://github.com/fastpyxl/fastpyxl/issues/1162>`_ Exception on tables with names containing spaces.
-* `#1170 <https://github.com/fastpyxl/fastpyxl/issues/1170>`_ Cannot save files with existing images.
+* `#1162 <https://github.com/openpyxl/openpyxl/issues/1162>`_ Exception on tables with names containing spaces.
+* `#1170 <https://github.com/openpyxl/openpyxl/issues/1170>`_ Cannot save files with existing images.
 
 
 2.6.-b1 (2019-01-08)
-====================
+--------------------
 
 
 Bugfixes
 --------
 
-* `#1141 <https://github.com/fastpyxl/fastpyxl/issues/1141>`_ Cannot use read-only mode with stream
-* `#1143 <https://github.com/fastpyxl/fastpyxl/issues/1143>`_ Hyperlinks always set on A1
-* `#1151 <https://github.com/fastpyxl/fastpyxl/issues/1151>`_ Internal row counter not initialised when reading files
-* `#1152 <https://github.com/fastpyxl/fastpyxl/issues/1152>`_ Exception raised on out of bounds date
+* `#1141 <https://github.com/openpyxl/openpyxl/issues/1141>`_ Cannot use read-only mode with stream
+* `#1143 <https://github.com/openpyxl/openpyxl/issues/1143>`_ Hyperlinks always set on A1
+* `#1151 <https://github.com/openpyxl/openpyxl/issues/1151>`_ Internal row counter not initialised when reading files
+* `#1152 <https://github.com/openpyxl/openpyxl/issues/1152>`_ Exception raised on out of bounds date
 
 
 2.6-a1 (2018-11-21)
-===================
+-------------------
 
 
 Major changes
@@ -423,185 +434,185 @@ Deprecations
 
 
 2.5.14 (2019-01-23)
-===================
+-------------------
 
 
 Bugfixes
 --------
 
-* `#1150 <https://github.com/fastpyxl/fastpyxl/issues/1150>`_ Correct typo in LineProperties
-* `#1142 <https://github.com/fastpyxl/fastpyxl/issues/1142>`_ Exception raised for unsupported image files
-* `#1159 <https://github.com/fastpyxl/fastpyxl/issues/1159>`_ Exception raised when cannot find source for non-local cache object
+* `#1150 <https://github.com/openpyxl/openpyxl/issues/1150>`_ Correct typo in LineProperties
+* `#1142 <https://github.com/openpyxl/openpyxl/issues/1142>`_ Exception raised for unsupported image files
+* `#1159 <https://github.com/openpyxl/openpyxl/issues/1159>`_ Exception raised when cannot find source for non-local cache object
 
 
 Pull Requests
 -------------
 
-* `PR301 <https://github.com/fastpyxl/fastpyxl/pull/301/>`_ Add support for nested brackets to the tokeniser
-* `PR303 <https://github.com/fastpyxl/fastpyxl/pull/301/>`_ Improvements on handling nested brackets in the tokeniser
+* `PR301 <https://github.com/openpyxl/openpyxl/pull/301/>`_ Add support for nested brackets to the tokeniser
+* `PR303 <https://github.com/openpyxl/openpyxl/pull/301/>`_ Improvements on handling nested brackets in the tokeniser
 
 
 2.5.13 (brown bag)
-==================
+------------------
 
 
 2.5.12 (2018-11-29)
-===================
+-------------------
 
 
 Bugfixes
 --------
 
-* `#1130 <https://github.com/fastpyxl/fastpyxl/issues/1130>`_ Overwriting default font in Normal style affects library default
-* `#1133 <https://github.com/fastpyxl/fastpyxl/issues/1133>`_ Images not added to anchors.
-* `#1134 <https://github.com/fastpyxl/fastpyxl/issues/1134>`_ Cannot read pivot table formats without dxId
-* `#1138 <https://github.com/fastpyxl/fastpyxl/issues/1138>`_ Repeated registration of simple filter could lead to memory leaks
+* `#1130 <https://github.com/openpyxl/openpyxl/issues/1130>`_ Overwriting default font in Normal style affects library default
+* `#1133 <https://github.com/openpyxl/openpyxl/issues/1133>`_ Images not added to anchors.
+* `#1134 <https://github.com/openpyxl/openpyxl/issues/1134>`_ Cannot read pivot table formats without dxId
+* `#1138 <https://github.com/openpyxl/openpyxl/issues/1138>`_ Repeated registration of simple filter could lead to memory leaks
 
 
 Pull Requests
 -------------
 
-* `PR300 <https://github.com/fastpyxl/fastpyxl/pull/300/>`_ Use defusedxml if available
+* `PR300 <https://github.com/openpyxl/openpyxl/pull/300/>`_ Use defusedxml if available
 
 
 2.5.11 (2018-11-21)
-===================
+-------------------
 
 
 Pull Requests
 -------------
 
-* `PR295 <https://github.com/fastpyxl/fastpyxl/pull/295>`_ Improved handling of missing rows
-* `PR296 <https://github.com/fastpyxl/fastpyxl/pull/296>`_ Add support for defined names to tokeniser
+* `PR295 <https://github.com/openpyxl/openpyxl/pull/295>`_ Improved handling of missing rows
+* `PR296 <https://github.com/openpyxl/openpyxl/pull/296>`_ Add support for defined names to tokeniser
 
 
 2.5.10 (2018-11-13)
-===================
+-------------------
 
 
 Bugfixes
 --------
 
-* `#1114 <https://github.com/fastpyxl/fastpyxl/issues/1114>`_ Empty column dimensions should not be saved.
+* `#1114 <https://github.com/openpyxl/openpyxl/issues/1114>`_ Empty column dimensions should not be saved.
 
 
 Pull Requests
 -------------
 
-* `PR285 <https://github.com/fastpyxl/fastpyxl/pull/285>`_ Tokenizer failure for quoted sheet name in second half of range
-* `PR289 <https://github.com/fastpyxl/fastpyxl/pull/289>`_ Improved error detection in ranges.
+* `PR285 <https://github.com/openpyxl/openpyxl/pull/285>`_ Tokenizer failure for quoted sheet name in second half of range
+* `PR289 <https://github.com/openpyxl/openpyxl/pull/289>`_ Improved error detection in ranges.
 
 
 2.5.9 (2018-10-19)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#1000 <https://github.com/fastpyxl/fastpyxl/issues/1000>`_ Clean AutoFilter name definitions
-* `#1106 <https://github.com/fastpyxl/fastpyxl/issues/1106>`_ Attribute missing from Shape object
-* `#1109 <https://github.com/fastpyxl/fastpyxl/issues/1109>`_ Failure to read all DrawingML means workbook can't be read
+* `#1000 <https://github.com/openpyxl/openpyxl/issues/1000>`_ Clean AutoFilter name definitions
+* `#1106 <https://github.com/openpyxl/openpyxl/issues/1106>`_ Attribute missing from Shape object
+* `#1109 <https://github.com/openpyxl/openpyxl/issues/1109>`_ Failure to read all DrawingML means workbook can't be read
 
 
 Pull Requests
 -------------
 
-* `PR281 <https://github.com/fastpyxl/fastpyxl/pull/281>`_ Allow newlines in formulae
-* `PR284 <https://github.com/fastpyxl/fastpyxl/pull/284>`_ Fix whitespace in front of infix operator in formulae
+* `PR281 <https://github.com/openpyxl/openpyxl/pull/281>`_ Allow newlines in formulae
+* `PR284 <https://github.com/openpyxl/openpyxl/pull/284>`_ Fix whitespace in front of infix operator in formulae
 
 
 2.5.8 (2018-09-25)
-==================
+------------------
 
 
-* `#877 <https://github.com/fastpyxl/fastpyxl/issues/877>`_ Cannot control how missing values are displayed in charts.
-* `#948 <https://github.com/fastpyxl/fastpyxl/issues/948>`_ Cell references can't be used for chart titles
-* `#1095 <https://github.com/fastpyxl/fastpyxl/issues/1095>`_ Params in iter_cols and iter_rows methods are slightly wrong.
+* `#877 <https://github.com/openpyxl/openpyxl/issues/877>`_ Cannot control how missing values are displayed in charts.
+* `#948 <https://github.com/openpyxl/openpyxl/issues/948>`_ Cell references can't be used for chart titles
+* `#1095 <https://github.com/openpyxl/openpyxl/issues/1095>`_ Params in iter_cols and iter_rows methods are slightly wrong.
 
 
 2.5.7 (2018-09-13)
-==================
+------------------
 
 
-* `#954 <https://github.com/fastpyxl/fastpyxl/issues/954>`_ Sheet title containing % need quoting in references
-* `#1047 <https://github.com/fastpyxl/fastpyxl/issues/1047>`_ Cannot set quote prefix
-* `#1093 <https://github.com/fastpyxl/fastpyxl/issues/1093>`_ Pandas timestamps raise KeyError
+* `#954 <https://github.com/openpyxl/openpyxl/issues/954>`_ Sheet title containing % need quoting in references
+* `#1047 <https://github.com/openpyxl/openpyxl/issues/1047>`_ Cannot set quote prefix
+* `#1093 <https://github.com/openpyxl/openpyxl/issues/1093>`_ Pandas timestamps raise KeyError
 
 
 2.5.6 (2018-08-30)
-==================
+------------------
 
 
-* `#832 <https://github.com/fastpyxl/fastpyxl/issues/832>`_ Read-only mode can leave find-handles open when reading dimensions
-* `#933 <https://github.com/fastpyxl/fastpyxl/issues/933>`_ Set a worksheet directly as active
-* `#1086 <https://github.com/fastpyxl/fastpyxl/issues/1086>`_ Internal row counter not adjusted when rows are deleted or inserted
+* `#832 <https://github.com/openpyxl/openpyxl/issues/832>`_ Read-only mode can leave find-handles open when reading dimensions
+* `#933 <https://github.com/openpyxl/openpyxl/issues/933>`_ Set a worksheet directly as active
+* `#1086 <https://github.com/openpyxl/openpyxl/issues/1086>`_ Internal row counter not adjusted when rows are deleted or inserted
 
 
 2.5.5 (2018-08-04)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#1049 <https://github.com/fastpyxl/fastpyxl/issues/1049>`_ Files with Mac epoch are read incorrectly
-* `#1058 <https://github.com/fastpyxl/fastpyxl/issues/1058>`_ Cannot copy merged cells
-* `#1066 <https://github.com/fastpyxl/fastpyxl/issues/1066>`_ Cannot access ws.active_cell
+* `#1049 <https://github.com/openpyxl/openpyxl/issues/1049>`_ Files with Mac epoch are read incorrectly
+* `#1058 <https://github.com/openpyxl/openpyxl/issues/1058>`_ Cannot copy merged cells
+* `#1066 <https://github.com/openpyxl/openpyxl/issues/1066>`_ Cannot access ws.active_cell
 
 
 Pull Requests
 -------------
 
-* `PR267 <https://github.com/fastpyxl/fastpyxl/pull/267/image-read>`_ Introduce read-support for images
+* `PR267 <https://github.com/openpyxl/openpyxl/pull/267/image-read>`_ Introduce read-support for images
 
 
 2.5.4 (2018-06-07)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#1025 <https://github.com/fastpyxl/fastpyxl/issues/1025>`_ Cannot read files with 3D charts.
-* `#1030 <https://github.com/fastpyxl/fastpyxl/issues/1030>`_ Merged cells take a long time to parse
+* `#1025 <https://github.com/openpyxl/openpyxl/issues/1025>`_ Cannot read files with 3D charts.
+* `#1030 <https://github.com/openpyxl/openpyxl/issues/1030>`_ Merged cells take a long time to parse
 
 
 Minor changes
 -------------
 
 * Improve read support for pivot tables and don't always create a Filters child for filterColumn objects.
-* `Support folding rows` <https://github.com/fastpyxl/fastpyxl/pull/259/fold-rows>`_
+* `Support folding rows` <https://github.com/openpyxl/openpyxl/pull/259/fold-rows>`_
 
 
 2.5.3 (2018-04-18)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#983 <https://github.com/fastpyxl/fastpyxl/issues/983>`_ Warning level too aggressive.
-* `#1015 <https://github.com/fastpyxl/fastpyxl/issues/1015>`_ Alignment and protection values not saved for named styles.
-* `#1017 <https://github.com/fastpyxl/fastpyxl/issues/1017>`_ Deleting elements from a legend doesn't work.
-* `#1018 <https://github.com/fastpyxl/fastpyxl/issues/1018>`_ Index names repeated for every row in dataframe.
-* `#1020 <https://github.com/fastpyxl/fastpyxl/issues/1020>`_ Worksheet protection not being stored.
-* `#1023 <https://github.com/fastpyxl/fastpyxl/issues/1023>`_ Exception raised when reading a tooltip.
+* `#983 <https://github.com/openpyxl/openpyxl/issues/983>`_ Warning level too aggressive.
+* `#1015 <https://github.com/openpyxl/openpyxl/issues/1015>`_ Alignment and protection values not saved for named styles.
+* `#1017 <https://github.com/openpyxl/openpyxl/issues/1017>`_ Deleting elements from a legend doesn't work.
+* `#1018 <https://github.com/openpyxl/openpyxl/issues/1018>`_ Index names repeated for every row in dataframe.
+* `#1020 <https://github.com/openpyxl/openpyxl/issues/1020>`_ Worksheet protection not being stored.
+* `#1023 <https://github.com/openpyxl/openpyxl/issues/1023>`_ Exception raised when reading a tooltip.
 
 
 2.5.2 (2018-04-06)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#949 <https://github.com/fastpyxl/fastpyxl/issues/949>`_ High memory use when reading text-heavy files.
-* `#970 <https://github.com/fastpyxl/fastpyxl/issues/970>`_ Copying merged cells copies references.
-* `#978 <https://github.com/fastpyxl/fastpyxl/issues/978>`_ Cannot set comment size.
-* `#985 <https://github.com/fastpyxl/fastpyxl/issues/895>`_ Exception when trying to save workbooks with no views.
-* `#995 <https://github.com/fastpyxl/fastpyxl/issues/995>`_ Cannot delete last row or column.
-* `#1002 <https://github.com/fastpyxl/fastpyxl/issues/1002>`_ Cannot read Drawings containing embedded images.
+* `#949 <https://github.com/openpyxl/openpyxl/issues/949>`_ High memory use when reading text-heavy files.
+* `#970 <https://github.com/openpyxl/openpyxl/issues/970>`_ Copying merged cells copies references.
+* `#978 <https://github.com/openpyxl/openpyxl/issues/978>`_ Cannot set comment size.
+* `#985 <https://github.com/openpyxl/openpyxl/issues/895>`_ Exception when trying to save workbooks with no views.
+* `#995 <https://github.com/openpyxl/openpyxl/issues/995>`_ Cannot delete last row or column.
+* `#1002 <https://github.com/openpyxl/openpyxl/issues/1002>`_ Cannot read Drawings containing embedded images.
 
 
 Minor changes
@@ -611,26 +622,26 @@ Minor changes
 
 
 2.5.1 (2018-03-12)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#934 <https://github.com/fastpyxl/fastpyxl/issues/934>`_ Headers and footers not included in write-only mode.
-* `#960 <https://github.com/fastpyxl/fastpyxl/issues/960>`_ Deprecation warning raised when using ad-hoc access in read-only mode.
-* `#964 <https://github.com/fastpyxl/fastpyxl/issues/964>`_ Not all cells removed when deleting multiple rows.
-* `#966 <https://github.com/fastpyxl/fastpyxl/issues/966>`_ Cannot read 3d bar chart correctly.
-* `#967 <https://github.com/fastpyxl/fastpyxl/issues/967>`_ Problems reading some charts.
-* `#968 <https://github.com/fastpyxl/fastpyxl/issues/968>`_ Worksheets with SHA protection become corrupted after saving.
-* `#974 <https://github.com/fastpyxl/fastpyxl/issues/974>`_ Problem when deleting ragged rows or columns.
-* `#976 <https://github.com/fastpyxl/fastpyxl/issues/976>`_ GroupTransforms and GroupShapeProperties have incorrect descriptors
+* `#934 <https://github.com/openpyxl/openpyxl/issues/934>`_ Headers and footers not included in write-only mode.
+* `#960 <https://github.com/openpyxl/openpyxl/issues/960>`_ Deprecation warning raised when using ad-hoc access in read-only mode.
+* `#964 <https://github.com/openpyxl/openpyxl/issues/964>`_ Not all cells removed when deleting multiple rows.
+* `#966 <https://github.com/openpyxl/openpyxl/issues/966>`_ Cannot read 3d bar chart correctly.
+* `#967 <https://github.com/openpyxl/openpyxl/issues/967>`_ Problems reading some charts.
+* `#968 <https://github.com/openpyxl/openpyxl/issues/968>`_ Worksheets with SHA protection become corrupted after saving.
+* `#974 <https://github.com/openpyxl/openpyxl/issues/974>`_ Problem when deleting ragged rows or columns.
+* `#976 <https://github.com/openpyxl/openpyxl/issues/976>`_ GroupTransforms and GroupShapeProperties have incorrect descriptors
 * Make sure that headers and footers in chartsheets are included in the file
 
 
 
 2.5.0 (2018-01-24)
-==================
+------------------
 
 
 Minor changes
@@ -640,19 +651,19 @@ Minor changes
 
 
 2.5.0-b2 (2018-01-19)
-=====================
+---------------------
 
 
 Bugfixes
 --------
 
-* `#915 <https://github.com/fastpyxl/fastpyxl/issues/915>`_ TableStyleInfo has no required attributes
-* `#925 <https://github.com/fastpyxl/fastpyxl/issues/925>`_ Cannot read files with 3D drawings
-* `#926 <https://github.com/fastpyxl/fastpyxl/issues/926>`_ Incorrect version check in installer
+* `#915 <https://github.com/openpyxl/openpyxl/issues/915>`_ TableStyleInfo has no required attributes
+* `#925 <https://github.com/openpyxl/openpyxl/issues/925>`_ Cannot read files with 3D drawings
+* `#926 <https://github.com/openpyxl/openpyxl/issues/926>`_ Incorrect version check in installer
 * Cell merging uses transposed parameters
-* `#928 <https://github.com/fastpyxl/fastpyxl/issues/928>`_ ExtLst missing keyword for PivotFields
-* `#932 <https://github.com/fastpyxl/fastpyxl/issues/932>`_ Inf causes problems for Excel
-* `#952 <https://github.com/fastpyxl/fastpyxl/issues/952>`_ Cannot load table styles with custom names
+* `#928 <https://github.com/openpyxl/openpyxl/issues/928>`_ ExtLst missing keyword for PivotFields
+* `#932 <https://github.com/openpyxl/openpyxl/issues/932>`_ Inf causes problems for Excel
+* `#952 <https://github.com/openpyxl/openpyxl/issues/952>`_ Cannot load table styles with custom names
 
 
 Major Changes
@@ -668,22 +679,22 @@ Minor Changes
 
 
 2.5.0-b1 (2017-10-19)
-=====================
+---------------------
 
 
 Bugfixes
 --------
-* `#812 <https://github.com/fastpyxl/fastpyxl/issues/812>`_ Explicitly support for multiple cell ranges in conditonal formatting
-* `#827 <https://github.com/fastpyxl/fastpyxl/issues/827>`_ Non-contiguous cell ranges in validators get merged
-* `#837 <https://github.com/fastpyxl/fastpyxl/issues/837>`_ Empty data validators create invalid Excel files
-* `#860 <https://github.com/fastpyxl/fastpyxl/issues/860>`_ Large validation ranges use lots of memory
-* `#876 <https://github.com/fastpyxl/fastpyxl/issues/876>`_ Unicode in chart axes not handled correctly in Python 2
-* `#882 <https://github.com/fastpyxl/fastpyxl/issues/882>`_ ScatterCharts have defective axes
-* `#885 <https://github.com/fastpyxl/fastpyxl/issues/885>`_ Charts with empty numVal elements cannot be read
-* `#894 <https://github.com/fastpyxl/fastpyxl/issues/894>`_ Scaling options from existing files ignored
-* `#895 <https://github.com/fastpyxl/fastpyxl/issues/895>`_ Charts with PivotSource cannot be read
-* `#903 <https://github.com/fastpyxl/fastpyxl/issues/903>`_ Cannot read gradient fills
-* `#904 <https://github.com/fastpyxl/fastpyxl/issues/904>`_ Quotes in number formats could be treated as datetimes
+* `#812 <https://github.com/openpyxl/openpyxl/issues/812>`_ Explicitly support for multiple cell ranges in conditonal formatting
+* `#827 <https://github.com/openpyxl/openpyxl/issues/827>`_ Non-contiguous cell ranges in validators get merged
+* `#837 <https://github.com/openpyxl/openpyxl/issues/837>`_ Empty data validators create invalid Excel files
+* `#860 <https://github.com/openpyxl/openpyxl/issues/860>`_ Large validation ranges use lots of memory
+* `#876 <https://github.com/openpyxl/openpyxl/issues/876>`_ Unicode in chart axes not handled correctly in Python 2
+* `#882 <https://github.com/openpyxl/openpyxl/issues/882>`_ ScatterCharts have defective axes
+* `#885 <https://github.com/openpyxl/openpyxl/issues/885>`_ Charts with empty numVal elements cannot be read
+* `#894 <https://github.com/openpyxl/openpyxl/issues/894>`_ Scaling options from existing files ignored
+* `#895 <https://github.com/openpyxl/openpyxl/issues/895>`_ Charts with PivotSource cannot be read
+* `#903 <https://github.com/openpyxl/openpyxl/issues/903>`_ Cannot read gradient fills
+* `#904 <https://github.com/openpyxl/openpyxl/issues/904>`_ Quotes in number formats could be treated as datetimes
 
 
 Major Changes
@@ -707,17 +718,17 @@ ws.merged_cell_ranges has been deprecated because MultiCellRange provides suffic
 
 
 2.5.0-a3 (2017-08-14)
-=====================
+---------------------
 
 
 Bugfixes
 --------
-* `#848 <https://github.com/fastpyxl/fastpyxl/issues/848>`_ Reading workbooks with Pie Charts raises an exception
-* `#857 <https://github.com/fastpyxl/fastpyxl/issues/857>`_ Pivot Tables without Worksheet Sources raise an exception
+* `#848 <https://github.com/openpyxl/openpyxl/issues/848>`_ Reading workbooks with Pie Charts raises an exception
+* `#857 <https://github.com/openpyxl/openpyxl/issues/857>`_ Pivot Tables without Worksheet Sources raise an exception
 
 
 2.5.0-a2 (2017-06-25)
-=====================
+---------------------
 
 
 Major Changes
@@ -728,13 +739,13 @@ Major Changes
 
 Bugfixes
 --------
-* `#833 <https://github.com/fastpyxl/fastpyxl/issues/833>`_ Cannot access chartsheets by title
-* `#834 <https://github.com/fastpyxl/fastpyxl/issues/834>`_ Preserve workbook views
-* `#841 <https://github.com/fastpyxl/fastpyxl/issues/841>`_ Incorrect classification of a datetime
+* `#833 <https://github.com/openpyxl/openpyxl/issues/833>`_ Cannot access chartsheets by title
+* `#834 <https://github.com/openpyxl/openpyxl/issues/834>`_ Preserve workbook views
+* `#841 <https://github.com/openpyxl/openpyxl/issues/841>`_ Incorrect classification of a datetime
 
 
 2.5.0-a1 (2017-05-30)
-=====================
+---------------------
 
 
 Compatibility
@@ -757,13 +768,13 @@ Deprecations
 
 Bugfixes
 --------
-* `#779 <https://github.com/fastpyxl/fastpyxl/issues/779>`_ Fails to recognise Chinese date format`
-* `#828 <https://github.com/fastpyxl/fastpyxl/issues/828>`_ Include hidden cells in charts`
+* `#779 <https://github.com/openpyxl/openpyxl/issues/779>`_ Fails to recognise Chinese date format`
+* `#828 <https://github.com/openpyxl/openpyxl/issues/828>`_ Include hidden cells in charts`
 
 
 Pull requests
 -------------
-* `163 <https://github.com/fastpyxl/fastpyxl/pull/163>`_ Improved GradientFill
+* `163 <https://github.com/openpyxl/openpyxl/pull/163>`_ Improved GradientFill
 
 
 Minor changes
@@ -775,74 +786,74 @@ Minor changes
 
 
 2.4.11 (2018-01-24)
-===================
+-------------------
 
-* #957 `<https://github.com/fastpyxl/fastpyxl/issues/957>`_ Relationship type for tables is borked
+* #957 `<https://github.com/openpyxl/openpyxl/issues/957>`_ Relationship type for tables is borked
 
 
 2.4.10 (2018-01-19)
-===================
+-------------------
 
 Bugfixes
 --------
 
-* #912 `<https://github.com/fastpyxl/fastpyxl/issues/912>`_ Copying objects uses shallow copy
-* #921 `<https://github.com/fastpyxl/fastpyxl/issues/921>`_ API documentation not generated automatically
-* #927 `<https://github.com/fastpyxl/fastpyxl/issues/927>`_ Exception raised when adding coloured borders together
-* #931 `<https://github.com/fastpyxl/fastpyxl/issues/931>`_ Number formats not correctly deduplicated
+* #912 `<https://github.com/openpyxl/openpyxl/issues/912>`_ Copying objects uses shallow copy
+* #921 `<https://github.com/openpyxl/openpyxl/issues/921>`_ API documentation not generated automatically
+* #927 `<https://github.com/openpyxl/openpyxl/issues/927>`_ Exception raised when adding coloured borders together
+* #931 `<https://github.com/openpyxl/openpyxl/issues/931>`_ Number formats not correctly deduplicated
 
 
 Pull requests
 -------------
 
-* 203 `<https://github.com/fastpyxl/fastpyxl/pull/203/>`_ Correction to worksheet protection description
-* 210 `<https://github.com/fastpyxl/fastpyxl/pull/210/>`_ Some improvements to the API docs
-* 211 `<https://github.com/fastpyxl/fastpyxl/pull/211/>`_ Improved deprecation decorator
-* 218 `<https://github.com/fastpyxl/fastpyxl/pull/218/>`_ Fix problems with deepcopy
+* 203 `<https://github.com/openpyxl/openpyxl/pull/203/>`_ Correction to worksheet protection description
+* 210 `<https://github.com/openpyxl/openpyxl/pull/210/>`_ Some improvements to the API docs
+* 211 `<https://github.com/openpyxl/openpyxl/pull/211/>`_ Improved deprecation decorator
+* 218 `<https://github.com/openpyxl/openpyxl/pull/218/>`_ Fix problems with deepcopy
 
 
 2.4.9 (2017-10-19)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#809 <https://github.com/fastpyxl/fastpyxl/issues/809>`_ Incomplete documentation of `copy_worksheet` method
-* `#811 <https://github.com/fastpyxl/fastpyxl/issues/811>`_ Scoped definedNames not removed when worksheet is deleted
-* `#824 <https://github.com/fastpyxl/fastpyxl/issues/824>`_ Raise an exception if a chart is used in multiple sheets
-* `#842 <https://github.com/fastpyxl/fastpyxl/issues/842>`_ Non-ASCII table column headings cause an exception in Python 2
-* `#846 <https://github.com/fastpyxl/fastpyxl/issues/846>`_ Conditional formats not supported in write-only mode
-* `#849 <https://github.com/fastpyxl/fastpyxl/issues/849>`_ Conditional formats with no sqref cause an exception
-* `#859 <https://github.com/fastpyxl/fastpyxl/issues/859>`_ Headers that start with a number conflict with font size
-* `#902 <https://github.com/fastpyxl/fastpyxl/issues/902>`_ TableStyleElements don't always have a condtional format
-* `#908 <https://github.com/fastpyxl/fastpyxl/issues/908>`_ Read-only mode sometimes returns too many cells
+* `#809 <https://github.com/openpyxl/openpyxl/issues/809>`_ Incomplete documentation of `copy_worksheet` method
+* `#811 <https://github.com/openpyxl/openpyxl/issues/811>`_ Scoped definedNames not removed when worksheet is deleted
+* `#824 <https://github.com/openpyxl/openpyxl/issues/824>`_ Raise an exception if a chart is used in multiple sheets
+* `#842 <https://github.com/openpyxl/openpyxl/issues/842>`_ Non-ASCII table column headings cause an exception in Python 2
+* `#846 <https://github.com/openpyxl/openpyxl/issues/846>`_ Conditional formats not supported in write-only mode
+* `#849 <https://github.com/openpyxl/openpyxl/issues/849>`_ Conditional formats with no sqref cause an exception
+* `#859 <https://github.com/openpyxl/openpyxl/issues/859>`_ Headers that start with a number conflict with font size
+* `#902 <https://github.com/openpyxl/openpyxl/issues/902>`_ TableStyleElements don't always have a condtional format
+* `#908 <https://github.com/openpyxl/openpyxl/issues/908>`_ Read-only mode sometimes returns too many cells
 
 
 
 Pull requests
 -------------
 
-* `#179 <https://github.com/fastpyxl/fastpyxl/pull/179>`_ Cells kept in a set
-* `#180 <https://github.com/fastpyxl/fastpyxl/pull/180>`_ Support for Workbook protection
-* `#182 <https://github.com/fastpyxl/fastpyxl/pull/182>`_ Read support for page breaks
-* `#183 <https://github.com/fastpyxl/fastpyxl/pull/183>`_ Improve documentation of `copy_worksheet` method
-* `#198 <https://github.com/fastpyxl/fastpyxl/pull/198>`_ Fix for #908
+* `#179 <https://github.com/openpyxl/openpyxl/pull/179>`_ Cells kept in a set
+* `#180 <https://github.com/openpyxl/openpyxl/pull/180>`_ Support for Workbook protection
+* `#182 <https://github.com/openpyxl/openpyxl/pull/182>`_ Read support for page breaks
+* `#183 <https://github.com/openpyxl/openpyxl/pull/183>`_ Improve documentation of `copy_worksheet` method
+* `#198 <https://github.com/openpyxl/openpyxl/pull/198>`_ Fix for #908
 
 
 2.4.8 (2017-05-30)
-==================
+------------------
 
 
 Bugfixes
 --------
 
 * AutoFilter.sortState being assignd to the ws.sortState
-* `#766 <https://github.com/fastpyxl/fastpyxl/issues/666>`_ Sheetnames with apostrophes need additional escaping
-* `#729 <https://github.com/fastpyxl/fastpyxl/issues/729>`_ Cannot open files created by Microsoft Dynamics
-* `#819 <https://github.com/fastpyxl/fastpyxl/issues/819>`_ Negative percents not case correctly
-* `#821 <https://github.com/fastpyxl/fastpyxl/issues/821>`_ Runtime imports can cause deadlock
-* `#855 <https://github.com/fastpyxl/fastpyxl/issues/855>`_ Print area containing only columns leads to corrupt file
+* `#766 <https://github.com/openpyxl/openpyxl/issues/666>`_ Sheetnames with apostrophes need additional escaping
+* `#729 <https://github.com/openpyxl/openpyxl/issues/729>`_ Cannot open files created by Microsoft Dynamics
+* `#819 <https://github.com/openpyxl/openpyxl/issues/819>`_ Negative percents not case correctly
+* `#821 <https://github.com/openpyxl/openpyxl/issues/821>`_ Runtime imports can cause deadlock
+* `#855 <https://github.com/openpyxl/openpyxl/issues/855>`_ Print area containing only columns leads to corrupt file
 
 
 Minor changes
@@ -851,60 +862,60 @@ Minor changes
 
 
 2.4.7 (2017-04-24)
-==================
+------------------
 
 
 Bugfixes
 --------
-* `#807 <https://github.com/fastpyxl/fastpyxl/issues/807>`_ Sample files being included by mistake in sdist
+* `#807 <https://github.com/openpyxl/openpyxl/issues/807>`_ Sample files being included by mistake in sdist
 
 
 2.4.6 (2017-04-14)
-==================
+------------------
 
 
 Bugfixes
 --------
-* `#776 <https://github.com/fastpyxl/fastpyxl/issues/776>`_ Cannot apply formatting to plot area
-* `#780 <https://github.com/fastpyxl/fastpyxl/issues/780>`_ Exception when element attributes are Python keywords
-* `#781 <https://github.com/fastpyxl/fastpyxl/issues/781>`_ Exception raised when saving files with styled columns
-* `#785 <https://github.com/fastpyxl/fastpyxl/issues/785>`_ Number formats for data labels are incorrect
-* `#788 <https://github.com/fastpyxl/fastpyxl/issues/788>`_ Worksheet titles not quoted in defined names
-* `#800 <https://github.com/fastpyxl/fastpyxl/issues/800>`_ Font underlines not read correctly
+* `#776 <https://github.com/openpyxl/openpyxl/issues/776>`_ Cannot apply formatting to plot area
+* `#780 <https://github.com/openpyxl/openpyxl/issues/780>`_ Exception when element attributes are Python keywords
+* `#781 <https://github.com/openpyxl/openpyxl/issues/781>`_ Exception raised when saving files with styled columns
+* `#785 <https://github.com/openpyxl/openpyxl/issues/785>`_ Number formats for data labels are incorrect
+* `#788 <https://github.com/openpyxl/openpyxl/issues/788>`_ Worksheet titles not quoted in defined names
+* `#800 <https://github.com/openpyxl/openpyxl/issues/800>`_ Font underlines not read correctly
 
 
 2.4.5 (2017-03-07)
-==================
+------------------
 
 
 Bugfixes
 --------
-* `#750 <https://github.com/fastpyxl/fastpyxl/issues/750>`_ Adding images keeps file handles open
-* `#772 <https://github.com/fastpyxl/fastpyxl/issues/772>`_ Exception for column-only ranges
-* `#773 <https://github.com/fastpyxl/fastpyxl/issues/773>`_ Cannot copy worksheets with non-ascii titles on Python 2
+* `#750 <https://github.com/openpyxl/openpyxl/issues/750>`_ Adding images keeps file handles open
+* `#772 <https://github.com/openpyxl/openpyxl/issues/772>`_ Exception for column-only ranges
+* `#773 <https://github.com/openpyxl/openpyxl/issues/773>`_ Cannot copy worksheets with non-ascii titles on Python 2
 
 
 Pull requests
 -------------
 
-* `161 <https://github.com/fastpyxl/fastpyxl/pull/161>`_ Support for non-standard names for Workbook part.
-* `162 <https://github.com/fastpyxl/fastpyxl/pull/162>`_ Documentation correction
+* `161 <https://github.com/openpyxl/openpyxl/pull/161>`_ Support for non-standard names for Workbook part.
+* `162 <https://github.com/openpyxl/openpyxl/pull/162>`_ Documentation correction
 
 
 2.4.4 (2017-02-23)
-==================
+------------------
 
 
 Bugfixes
 --------
 
-* `#673 <https://github.com/fastpyxl/fastpyxl/issues/673>`_ Add close method to workbooks
-* `#762 <https://github.com/fastpyxl/fastpyxl/issues/762>`_ fastpyxl can create files with invalid style indices
-* `#729 <https://github.com/fastpyxl/fastpyxl/issues/729>`_ Allow images in write-only mode
-* `#744 <https://github.com/fastpyxl/fastpyxl/issues/744>`_ Rounded corners for charts
-* `#747 <https://github.com/fastpyxl/fastpyxl/issues/747>`_ Use repr when handling non-convertible objects
-* `#764 <https://github.com/fastpyxl/fastpyxl/issues/764>`_ Hashing function is incorrect
-* `#765 <https://github.com/fastpyxl/fastpyxl/issues/765>`_ Named styles share underlying array
+* `#673 <https://github.com/openpyxl/openpyxl/issues/673>`_ Add close method to workbooks
+* `#762 <https://github.com/openpyxl/openpyxl/issues/762>`_ fastpyxl can create files with invalid style indices
+* `#729 <https://github.com/openpyxl/openpyxl/issues/729>`_ Allow images in write-only mode
+* `#744 <https://github.com/openpyxl/openpyxl/issues/744>`_ Rounded corners for charts
+* `#747 <https://github.com/openpyxl/openpyxl/issues/747>`_ Use repr when handling non-convertible objects
+* `#764 <https://github.com/openpyxl/openpyxl/issues/764>`_ Hashing function is incorrect
+* `#765 <https://github.com/openpyxl/openpyxl/issues/765>`_ Named styles share underlying array
 
 
 Minor Changes
@@ -916,31 +927,31 @@ Minor Changes
 Pull requests
 -------------
 
-* `160 <https://github.com/fastpyxl/fastpyxl/pull/160>`_ Don't init mimetypes more than once.
+* `160 <https://github.com/openpyxl/openpyxl/pull/160>`_ Don't init mimetypes more than once.
 
 
 2.4.3 (unreleased)
-==================
+------------------
 bad release
 
 
 2.4.2 (2017-01-31)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#727 <https://github.com/fastpyxl/fastpyxl/issues/727>`_ DeprecationWarning is incorrect
-* `#734 <https://github.com/fastpyxl/fastpyxl/issues/734>`_ Exception raised if userName is missing
-* `#739 <https://github.com/fastpyxl/fastpyxl/issues/739>`_ Always provide a date1904 attribute
-* `#740 <https://github.com/fastpyxl/fastpyxl/issues/740>`_ Hashes should be stored as Base64
-* `#743 <https://github.com/fastpyxl/fastpyxl/issues/743>`_ Print titles broken on sheetnames with spaces
-* `#748 <https://github.com/fastpyxl/fastpyxl/issues/748>`_ Workbook breaks when active sheet is removed
-* `#754 <https://github.com/fastpyxl/fastpyxl/issues/754>`_ Incorrect descriptor for Filter values
-* `#756 <https://github.com/fastpyxl/fastpyxl/issues/756>`_ Potential XXE vulerability
-* `#758 <https://github.com/fastpyxl/fastpyxl/issues/758>`_ Cannot create files with page breaks and charts
-* `#759 <https://github.com/fastpyxl/fastpyxl/issues/759>`_ Problems with worksheets with commas in their titles
+* `#727 <https://github.com/openpyxl/openpyxl/issues/727>`_ DeprecationWarning is incorrect
+* `#734 <https://github.com/openpyxl/openpyxl/issues/734>`_ Exception raised if userName is missing
+* `#739 <https://github.com/openpyxl/openpyxl/issues/739>`_ Always provide a date1904 attribute
+* `#740 <https://github.com/openpyxl/openpyxl/issues/740>`_ Hashes should be stored as Base64
+* `#743 <https://github.com/openpyxl/openpyxl/issues/743>`_ Print titles broken on sheetnames with spaces
+* `#748 <https://github.com/openpyxl/openpyxl/issues/748>`_ Workbook breaks when active sheet is removed
+* `#754 <https://github.com/openpyxl/openpyxl/issues/754>`_ Incorrect descriptor for Filter values
+* `#756 <https://github.com/openpyxl/openpyxl/issues/756>`_ Potential XXE vulerability
+* `#758 <https://github.com/openpyxl/openpyxl/issues/758>`_ Cannot create files with page breaks and charts
+* `#759 <https://github.com/openpyxl/openpyxl/issues/759>`_ Problems with worksheets with commas in their titles
 
 
 Minor Changes
@@ -950,28 +961,28 @@ Minor Changes
 
 
 2.4.1 (2016-11-23)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#643 <https://github.com/fastpyxl/fastpyxl/issues/643>`_ Make checking for duplicate sheet titles case insensitive
-* `#647 <https://github.com/fastpyxl/fastpyxl/issues/647>`_ Trouble handling LibreOffice files with named styles
-* `#687 <https://github.com/fastpyxl/fastpyxl/issues/682>`_ Directly assigned new named styles always refer to "Normal"
-* `#690 <https://github.com/fastpyxl/fastpyxl/issues/690>`_ Cannot parse print titles with multiple sheet names
-* `#691 <https://github.com/fastpyxl/fastpyxl/issues/691>`_ Cannot work with macro files created by LibreOffice
+* `#643 <https://github.com/openpyxl/openpyxl/issues/643>`_ Make checking for duplicate sheet titles case insensitive
+* `#647 <https://github.com/openpyxl/openpyxl/issues/647>`_ Trouble handling LibreOffice files with named styles
+* `#687 <https://github.com/openpyxl/openpyxl/issues/682>`_ Directly assigned new named styles always refer to "Normal"
+* `#690 <https://github.com/openpyxl/openpyxl/issues/690>`_ Cannot parse print titles with multiple sheet names
+* `#691 <https://github.com/openpyxl/openpyxl/issues/691>`_ Cannot work with macro files created by LibreOffice
 * Prevent duplicate differential styles
-* `#694 <https://github.com/fastpyxl/fastpyxl/issues/694>`_ Allow sheet titles longer than 31 characters
-* `#697 <https://github.com/fastpyxl/fastpyxl/issues/697>`_ Cannot unset hyperlinks
-* `#699 <https://github.com/fastpyxl/fastpyxl/issues/699>`_ Exception raised when format objects use cell references
-* `#703 <https://github.com/fastpyxl/fastpyxl/issues/703>`_ Copy height and width when copying comments
-* `#705 <https://github.com/fastpyxl/fastpyxl/issues/705>`_ Incorrect content type for VBA macros
-* `#707 <https://github.com/fastpyxl/fastpyxl/issues/707>`_ IndexError raised in read-only mode when accessing individual cells
-* `#711 <https://github.com/fastpyxl/fastpyxl/issues/711>`_ Files with external links become corrupted
-* `#715 <https://github.com/fastpyxl/fastpyxl/issues/715>`_ Cannot read files containing macro sheets
-* `#717 <https://github.com/fastpyxl/fastpyxl/issues/717>`_ Details from named styles not preserved when reading files
-* `#722 <https://github.com/fastpyxl/fastpyxl/issues/722>`_ Remove broken Print Title and Print Area definitions
+* `#694 <https://github.com/openpyxl/openpyxl/issues/694>`_ Allow sheet titles longer than 31 characters
+* `#697 <https://github.com/openpyxl/openpyxl/issues/697>`_ Cannot unset hyperlinks
+* `#699 <https://github.com/openpyxl/openpyxl/issues/699>`_ Exception raised when format objects use cell references
+* `#703 <https://github.com/openpyxl/openpyxl/issues/703>`_ Copy height and width when copying comments
+* `#705 <https://github.com/openpyxl/openpyxl/issues/705>`_ Incorrect content type for VBA macros
+* `#707 <https://github.com/openpyxl/openpyxl/issues/707>`_ IndexError raised in read-only mode when accessing individual cells
+* `#711 <https://github.com/openpyxl/openpyxl/issues/711>`_ Files with external links become corrupted
+* `#715 <https://github.com/openpyxl/openpyxl/issues/715>`_ Cannot read files containing macro sheets
+* `#717 <https://github.com/openpyxl/openpyxl/issues/717>`_ Details from named styles not preserved when reading files
+* `#722 <https://github.com/openpyxl/openpyxl/issues/722>`_ Remove broken Print Title and Print Area definitions
 
 
 Minor changes
@@ -992,17 +1003,17 @@ Bug fixes
 
 
 2.4.0 (2016-09-15)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#652 <https://github.com/fastpyxl/fastpyxl/issues/652>`_ Exception raised when epoch is 1904
-* `#642 <https://github.com/fastpyxl/fastpyxl/issues/642>`_ Cannot handle unicode in headers and footers in Python 2
-* `#646 <https://github.com/fastpyxl/fastpyxl/issues/646>`_ Cannot handle unicode sheetnames in Python 2
-* `#658 <https://github.com/fastpyxl/fastpyxl/issues/658>`_ Chart styles, and axis units should not be 0
-* `#663 <https://github.com/fastpyxl/fastpyxl/issues/663>`_ Strings in external workbooks not unicode
+* `#652 <https://github.com/openpyxl/openpyxl/issues/652>`_ Exception raised when epoch is 1904
+* `#642 <https://github.com/openpyxl/openpyxl/issues/642>`_ Cannot handle unicode in headers and footers in Python 2
+* `#646 <https://github.com/openpyxl/openpyxl/issues/646>`_ Cannot handle unicode sheetnames in Python 2
+* `#658 <https://github.com/openpyxl/openpyxl/issues/658>`_ Chart styles, and axis units should not be 0
+* `#663 <https://github.com/openpyxl/openpyxl/issues/663>`_ Strings in external workbooks not unicode
 
 
 Major changes
@@ -1022,7 +1033,7 @@ Minor changes
 
 
 2.4.0-b1 (2016-06-08)
-=====================
+---------------------
 
 
 Minor changes
@@ -1034,11 +1045,11 @@ Minor changes
 Bug fixes
 ---------
 
-* `#625 <https://github.com/fastpyxl/fastpyxl/issues/625>`_ Exception raises when inspecting EmptyCells in read-only mode
-* `#547 <https://github.com/fastpyxl/fastpyxl/issues/547>`_ Functions for handling OOXML "escaped" ST_XStrings
-* `#629 <https://github.com/fastpyxl/fastpyxl/issues/629>`_ Row Dimensions not supported in write-only mode
-* `#530 <https://github.com/fastpyxl/fastpyxl/issues/530>`_ Problems when removing worksheets with charts
-* `#630 <https://github.com/fastpyxl/fastpyxl/issues/630>`_ Cannot use SheetProtection in write-only mode
+* `#625 <https://github.com/openpyxl/openpyxl/issues/625>`_ Exception raises when inspecting EmptyCells in read-only mode
+* `#547 <https://github.com/openpyxl/openpyxl/issues/547>`_ Functions for handling OOXML "escaped" ST_XStrings
+* `#629 <https://github.com/openpyxl/openpyxl/issues/629>`_ Row Dimensions not supported in write-only mode
+* `#530 <https://github.com/openpyxl/openpyxl/issues/530>`_ Problems when removing worksheets with charts
+* `#630 <https://github.com/openpyxl/openpyxl/issues/630>`_ Cannot use SheetProtection in write-only mode
 
 
 Features
@@ -1048,7 +1059,7 @@ Features
 
 
 2.4.0-a1 (2016-04-11)
-=====================
+---------------------
 
 
 Minor changes
@@ -1089,39 +1100,39 @@ Deprecations
 Bug fixes
 ---------
 
-* `#152 <https://github.com/fastpyxl/fastpyxl/issues/152>`_ Hyperlinks lost when reading files
-* `#171 <https://github.com/fastpyxl/fastpyxl/issues/171>`_ Add function for copying worksheets
-* `#386 <https://github.com/fastpyxl/fastpyxl/issues/386>`_ Cells with inline strings considered empty
-* `#397 <https://github.com/fastpyxl/fastpyxl/issues/397>`_ Add support for ranges of rows and columns
-* `#446 <https://github.com/fastpyxl/fastpyxl/issues/446>`_ Workbook with definedNames corrupted by fastpyxl
-* `#481 <https://github.com/fastpyxl/fastpyxl/issues/481>`_ "safe" reserved ranges are not read from workbooks
-* `#501 <https://github.com/fastpyxl/fastpyxl/issues/501>`_ Discarding named ranges can lead to corrupt files
-* `#574 <https://github.com/fastpyxl/fastpyxl/issues/574>`_ Exception raised when using the class method to parse Relationships
-* `#579 <https://github.com/fastpyxl/fastpyxl/issues/579>`_ Crashes when reading defined names with no content
-* `#597 <https://github.com/fastpyxl/fastpyxl/issues/597>`_ Cannot read worksheets without coordinates
-* `#617 <https://github.com/fastpyxl/fastpyxl/issues/617>`_ Customised named styles not correctly preserved
+* `#152 <https://github.com/openpyxl/openpyxl/issues/152>`_ Hyperlinks lost when reading files
+* `#171 <https://github.com/openpyxl/openpyxl/issues/171>`_ Add function for copying worksheets
+* `#386 <https://github.com/openpyxl/openpyxl/issues/386>`_ Cells with inline strings considered empty
+* `#397 <https://github.com/openpyxl/openpyxl/issues/397>`_ Add support for ranges of rows and columns
+* `#446 <https://github.com/openpyxl/openpyxl/issues/446>`_ Workbook with definedNames corrupted by fastpyxl
+* `#481 <https://github.com/openpyxl/openpyxl/issues/481>`_ "safe" reserved ranges are not read from workbooks
+* `#501 <https://github.com/openpyxl/openpyxl/issues/501>`_ Discarding named ranges can lead to corrupt files
+* `#574 <https://github.com/openpyxl/openpyxl/issues/574>`_ Exception raised when using the class method to parse Relationships
+* `#579 <https://github.com/openpyxl/openpyxl/issues/579>`_ Crashes when reading defined names with no content
+* `#597 <https://github.com/openpyxl/openpyxl/issues/597>`_ Cannot read worksheets without coordinates
+* `#617 <https://github.com/openpyxl/openpyxl/issues/617>`_ Customised named styles not correctly preserved
 
 
 2.3.5 (2016-04-11)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#618 <https://github.com/fastpyxl/fastpyxl/issues/618>`_ Comments not written in write-only mode
+* `#618 <https://github.com/openpyxl/openpyxl/issues/618>`_ Comments not written in write-only mode
 
 
 2.3.4 (2016-03-16)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#594 <https://github.com/fastpyxl/fastpyxl/issues/594>`_ Content types might be missing when keeping VBA
-* `#599 <https://github.com/fastpyxl/fastpyxl/issues/599>`_ Cells with only one cell look empty
-* `#607 <https://github.com/fastpyxl/fastpyxl/issues/607>`_ Serialise NaN as ''
+* `#594 <https://github.com/openpyxl/openpyxl/issues/594>`_ Content types might be missing when keeping VBA
+* `#599 <https://github.com/openpyxl/openpyxl/issues/599>`_ Cells with only one cell look empty
+* `#607 <https://github.com/openpyxl/openpyxl/issues/607>`_ Serialise NaN as ''
 
 
 Minor changes
@@ -1132,73 +1143,73 @@ Minor changes
 
 
 2.3.3 (2016-01-18)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#540 <https://github.com/fastpyxl/fastpyxl/issues/540>`_ Cannot read merged cells in read-only mode
-* `#565 <https://github.com/fastpyxl/fastpyxl/issues/565>`_ Empty styled text blocks cannot be parsed
-* `#569 <https://github.com/fastpyxl/fastpyxl/issues/569>`_ Issue warning rather than raise Exception raised for unparsable definedNames
-* `#575 <https://github.com/fastpyxl/fastpyxl/issues/575>`_ Cannot open workbooks with embdedded OLE files
-* `#584 <https://github.com/fastpyxl/fastpyxl/issues/584>`_ Exception when saving borders with attributes
+* `#540 <https://github.com/openpyxl/openpyxl/issues/540>`_ Cannot read merged cells in read-only mode
+* `#565 <https://github.com/openpyxl/openpyxl/issues/565>`_ Empty styled text blocks cannot be parsed
+* `#569 <https://github.com/openpyxl/openpyxl/issues/569>`_ Issue warning rather than raise Exception raised for unparsable definedNames
+* `#575 <https://github.com/openpyxl/openpyxl/issues/575>`_ Cannot open workbooks with embdedded OLE files
+* `#584 <https://github.com/openpyxl/openpyxl/issues/584>`_ Exception when saving borders with attributes
 
 
 Minor changes
 -------------
 
-* `PR 103 <https://github.com/fastpyxl/fastpyxl/pull/103/>`_ Documentation about chart scaling and axis limits
+* `PR 103 <https://github.com/openpyxl/openpyxl/pull/103/>`_ Documentation about chart scaling and axis limits
 * Raise an exception when trying to copy cells from other workbooks.
 
 
 2.3.2 (2015-12-07)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#554 <https://github.com/fastpyxl/fastpyxl/issues/554>`_ Cannot add comments to a worksheet when preserving VBA
-* `#561 <https://github.com/fastpyxl/fastpyxl/issues/561>`_ Exception when reading phonetic text
-* `#562 <https://github.com/fastpyxl/fastpyxl/issues/562>`_ DARKBLUE is the same as RED
-* `#563 <https://github.com/fastpyxl/fastpyxl/issues/563>`_ Minimum for row and column indexes not enforced
+* `#554 <https://github.com/openpyxl/openpyxl/issues/554>`_ Cannot add comments to a worksheet when preserving VBA
+* `#561 <https://github.com/openpyxl/openpyxl/issues/561>`_ Exception when reading phonetic text
+* `#562 <https://github.com/openpyxl/openpyxl/issues/562>`_ DARKBLUE is the same as RED
+* `#563 <https://github.com/openpyxl/openpyxl/issues/563>`_ Minimum for row and column indexes not enforced
 
 
 Minor changes
 -------------
 
-* `PR 97 <https://github.com/fastpyxl/fastpyxl/pull/97/>`_ One VML file per worksheet.
-* `PR 96 <https://github.com/fastpyxl/fastpyxl/pull/96/>`_ Correct descriptor for CharacterProperties.rtl
-* `#498 <https://github.com/fastpyxl/fastpyxl/issues/498>`_ Metadata is not essential to use the package.
+* `PR 97 <https://github.com/openpyxl/openpyxl/pull/97/>`_ One VML file per worksheet.
+* `PR 96 <https://github.com/openpyxl/openpyxl/pull/96/>`_ Correct descriptor for CharacterProperties.rtl
+* `#498 <https://github.com/openpyxl/openpyxl/issues/498>`_ Metadata is not essential to use the package.
 
 
 2.3.1 (2015-11-20)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#534 <https://github.com/fastpyxl/fastpyxl/issues/534>`_ Exception when using columns property in read-only mode.
-* `#536 <https://github.com/fastpyxl/fastpyxl/issues/536>`_ Incorrectly handle comments from Google Docs files.
-* `#539 <https://github.com/fastpyxl/fastpyxl/issues/539>`_ Flexible value types for conditional formatting.
-* `#542 <https://github.com/fastpyxl/fastpyxl/issues/542>`_ Missing content types for images.
-* `#543 <https://github.com/fastpyxl/fastpyxl/issues/543>`_ Make sure images fit containers on all OSes.
-* `#544 <https://github.com/fastpyxl/fastpyxl/issues/544>`_ Gracefully handle missing cell styles.
-* `#546 <https://github.com/fastpyxl/fastpyxl/issues/546>`_ ExternalLink duplicated when editing a file with macros.
-* `#548 <https://github.com/fastpyxl/fastpyxl/issues/548>`_ Exception with non-ASCII worksheet titles
-* `#551 <https://github.com/fastpyxl/fastpyxl/issues/551>`_ Combine multiple LineCharts
+* `#534 <https://github.com/openpyxl/openpyxl/issues/534>`_ Exception when using columns property in read-only mode.
+* `#536 <https://github.com/openpyxl/openpyxl/issues/536>`_ Incorrectly handle comments from Google Docs files.
+* `#539 <https://github.com/openpyxl/openpyxl/issues/539>`_ Flexible value types for conditional formatting.
+* `#542 <https://github.com/openpyxl/openpyxl/issues/542>`_ Missing content types for images.
+* `#543 <https://github.com/openpyxl/openpyxl/issues/543>`_ Make sure images fit containers on all OSes.
+* `#544 <https://github.com/openpyxl/openpyxl/issues/544>`_ Gracefully handle missing cell styles.
+* `#546 <https://github.com/openpyxl/openpyxl/issues/546>`_ ExternalLink duplicated when editing a file with macros.
+* `#548 <https://github.com/openpyxl/openpyxl/issues/548>`_ Exception with non-ASCII worksheet titles
+* `#551 <https://github.com/openpyxl/openpyxl/issues/551>`_ Combine multiple LineCharts
 
 
 Minor changes
 -------------
 
-* `PR 88 <https://github.com/fastpyxl/fastpyxl/pull/88/>`_ Fix page margins in parser.
+* `PR 88 <https://github.com/openpyxl/openpyxl/pull/88/>`_ Fix page margins in parser.
 
 
 2.3.0 (2015-10-20)
-==================
+------------------
 
 
 Major changes
@@ -1210,7 +1221,7 @@ Major changes
 Bug fixes
 ---------
 
-* `#532 <https://github.com/fastpyxl/fastpyxl/issues/532>`_ Problems when cells have no style in read-only mode.
+* `#532 <https://github.com/openpyxl/openpyxl/issues/532>`_ Problems when cells have no style in read-only mode.
 
 
 Minor changes
@@ -1221,21 +1232,21 @@ Minor changes
 
 
 2.3.0-b2 (2015-09-04)
-=====================
+---------------------
 
 
 Bug fixes
 ---------
 
-* `#488 <https://bitbucket.org/fastpyxl/fastpyxl/issue/488>`_ Support hashValue attribute for sheetProtection
-* `#493 <https://bitbucket.org/fastpyxl/fastpyxl/issue/493>`_ Warn that unsupported extensions will be dropped
-* `#494 <https://github.com/fastpyxl/fastpyxl/issues/494/>`_ Cells with exponentials causes a ValueError
-* `#497 <https://github.com/fastpyxl/fastpyxl/issues/497/>`_ Scatter charts are broken
-* `#499 <https://github.com/fastpyxl/fastpyxl/issues/499/>`_ Inconsistent conversion of localised datetimes
-* `#500 <https://github.com/fastpyxl/fastpyxl/issues/500/>`_ Adding images leads to unreadable files
-* `#509 <https://github.com/fastpyxl/fastpyxl/issues/509/>`_ Improve handling of sheet names
-* `#515 <https://github.com/fastpyxl/fastpyxl/issues/515/>`_ Non-ascii titles have bad repr
-* `#516 <https://github.com/fastpyxl/fastpyxl/issues/516/>`_ Ignore unassigned worksheets
+* `#488 <https://bitbucket.org/openpyxl/openpyxl/issue/488>`_ Support hashValue attribute for sheetProtection
+* `#493 <https://bitbucket.org/openpyxl/openpyxl/issue/493>`_ Warn that unsupported extensions will be dropped
+* `#494 <https://github.com/openpyxl/openpyxl/issues/494/>`_ Cells with exponentials causes a ValueError
+* `#497 <https://github.com/openpyxl/openpyxl/issues/497/>`_ Scatter charts are broken
+* `#499 <https://github.com/openpyxl/openpyxl/issues/499/>`_ Inconsistent conversion of localised datetimes
+* `#500 <https://github.com/openpyxl/openpyxl/issues/500/>`_ Adding images leads to unreadable files
+* `#509 <https://github.com/openpyxl/openpyxl/issues/509/>`_ Improve handling of sheet names
+* `#515 <https://github.com/openpyxl/openpyxl/issues/515/>`_ Non-ascii titles have bad repr
+* `#516 <https://github.com/openpyxl/openpyxl/issues/516/>`_ Ignore unassigned worksheets
 
 
 Minor changes
@@ -1246,7 +1257,7 @@ Minor changes
 
 
 2.3.0-b1 (2015-06-29)
-=====================
+---------------------
 
 
 Major changes
@@ -1264,126 +1275,126 @@ Minor changes
 
 * Read-only and write-only worksheets renamed.
 * Write-only workbooks support charts and images.
-* `PR76 <https://bitbucket.org/fastpyxl/fastpyxl/pull-request/76>`_ Prevent comment images from conflicting with VBA
+* `PR76 <https://bitbucket.org/openpyxl/openpyxl/pull-request/76>`_ Prevent comment images from conflicting with VBA
 
 
 Bug fixes
 ---------
 
-* `#81 <https://bitbucket.org/fastpyxl/fastpyxl/issue/81>`_ Support stacked bar charts
-* `#88 <https://bitbucket.org/fastpyxl/fastpyxl/issue/88>`_ Charts break hyperlinks
-* `#97 <https://bitbucket.org/fastpyxl/fastpyxl/issue/97>`_ Pie and combination charts
-* `#99 <https://bitbucket.org/fastpyxl/fastpyxl/issue/99>`_ Quote worksheet names in chart references
-* `#150 <https://bitbucket.org/fastpyxl/fastpyxl/issue/150>`_ Support additional chart options
-* `#172 <https://bitbucket.org/fastpyxl/fastpyxl/issue/172>`_ Support surface charts
-* `#381 <https://bitbucket.org/fastpyxl/fastpyxl/issue/381>`_ Preserve named styles
-* `#470 <https://bitbucket.org/fastpyxl/fastpyxl/issue/470>`_ Adding more than 10 worksheets with the same name leads to duplicates sheet names and an invalid file
+* `#81 <https://bitbucket.org/openpyxl/openpyxl/issue/81>`_ Support stacked bar charts
+* `#88 <https://bitbucket.org/openpyxl/openpyxl/issue/88>`_ Charts break hyperlinks
+* `#97 <https://bitbucket.org/openpyxl/openpyxl/issue/97>`_ Pie and combination charts
+* `#99 <https://bitbucket.org/openpyxl/openpyxl/issue/99>`_ Quote worksheet names in chart references
+* `#150 <https://bitbucket.org/openpyxl/openpyxl/issue/150>`_ Support additional chart options
+* `#172 <https://bitbucket.org/openpyxl/openpyxl/issue/172>`_ Support surface charts
+* `#381 <https://bitbucket.org/openpyxl/openpyxl/issue/381>`_ Preserve named styles
+* `#470 <https://bitbucket.org/openpyxl/openpyxl/issue/470>`_ Adding more than 10 worksheets with the same name leads to duplicates sheet names and an invalid file
 
 
 2.2.6 (unreleased)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#502 <https://bitbucket.org/fastpyxl/fastpyxl/issue/502>`_ Unexpected keyword "mergeCell"
-* `#503 <https://bitbucket.org/fastpyxl/fastpyxl/issue/503>`_ tostring missing in dump_worksheet
-* `#506 <https://github.com/fastpyxl/fastpyxl/issues/506>`_ Non-ASCII formulae cannot be parsed
-* `#508 <https://github.com/fastpyxl/fastpyxl/issues/508>`_ Cannot save files with coloured tabs
+* `#502 <https://bitbucket.org/openpyxl/openpyxl/issue/502>`_ Unexpected keyword "mergeCell"
+* `#503 <https://bitbucket.org/openpyxl/openpyxl/issue/503>`_ tostring missing in dump_worksheet
+* `#506 <https://github.com/openpyxl/openpyxl/issues/506>`_ Non-ASCII formulae cannot be parsed
+* `#508 <https://github.com/openpyxl/openpyxl/issues/508>`_ Cannot save files with coloured tabs
 * Regex for ignoring named ranges is wrong (character class instead of prefix)
 
 
 2.2.5 (2015-06-29)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#463 <https://bitbucket.org/fastpyxl/fastpyxl/issue/463>`_ Unexpected keyword "mergeCell"
-* `#484 <https://bitbucket.org/fastpyxl/fastpyxl/issue/484>`_ Unusual dimensions breaks read-only mode
-* `#485 <https://bitbucket.org/fastpyxl/fastpyxl/issue/485>`_ Move return out of loop
+* `#463 <https://bitbucket.org/openpyxl/openpyxl/issue/463>`_ Unexpected keyword "mergeCell"
+* `#484 <https://bitbucket.org/openpyxl/openpyxl/issue/484>`_ Unusual dimensions breaks read-only mode
+* `#485 <https://bitbucket.org/openpyxl/openpyxl/issue/485>`_ Move return out of loop
 
 
 2.2.4 (2015-06-17)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#464 <https://bitbucket.org/fastpyxl/fastpyxl/issue/464>`_ Cannot use images when preserving macros
-* `#465 <https://bitbucket.org/fastpyxl/fastpyxl/issue/465>`_ ws.cell() returns an empty cell on read-only workbooks
-* `#467 <https://bitbucket.org/fastpyxl/fastpyxl/issue/467>`_ Cannot edit a file with ActiveX components
-* `#471 <https://bitbucket.org/fastpyxl/fastpyxl/issue/471>`_ Sheet properties elements must be in order
-* `#475 <https://bitbucket.org/fastpyxl/fastpyxl/issue/475>`_ Do not redefine class __slots__ in subclasses
-* `#477 <https://bitbucket.org/fastpyxl/fastpyxl/issue/477>`_ Write-only support for SheetProtection
-* `#478 <https://bitbucket.org/fastpyxl/fastpyxl/issue/477>`_ Write-only support for DataValidation
+* `#464 <https://bitbucket.org/openpyxl/openpyxl/issue/464>`_ Cannot use images when preserving macros
+* `#465 <https://bitbucket.org/openpyxl/openpyxl/issue/465>`_ ws.cell() returns an empty cell on read-only workbooks
+* `#467 <https://bitbucket.org/openpyxl/openpyxl/issue/467>`_ Cannot edit a file with ActiveX components
+* `#471 <https://bitbucket.org/openpyxl/openpyxl/issue/471>`_ Sheet properties elements must be in order
+* `#475 <https://bitbucket.org/openpyxl/openpyxl/issue/475>`_ Do not redefine class __slots__ in subclasses
+* `#477 <https://bitbucket.org/openpyxl/openpyxl/issue/477>`_ Write-only support for SheetProtection
+* `#478 <https://bitbucket.org/openpyxl/openpyxl/issue/477>`_ Write-only support for DataValidation
 * Improved regex when checking for datetime formats
 
 
 2.2.3 (2015-05-26)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#451 <https://bitbucket.org/fastpyxl/fastpyxl/issue/451>`_ fitToPage setting ignored
-* `#458 <https://bitbucket.org/fastpyxl/fastpyxl/issue/458>`_ Trailing spaces lost when saving files.
-* `#459 <https://bitbucket.org/fastpyxl/fastpyxl/issue/459>`_ setup.py install fails with Python 3
-* `#462 <https://bitbucket.org/fastpyxl/fastpyxl/issue/462>`_ Vestigial rId conflicts when adding charts, images or comments
-* `#455 <https://bitbucket.org/fastpyxl/fastpyxl/issue/455>`_ Enable Zip64 extensions for all versions of Python
+* `#451 <https://bitbucket.org/openpyxl/openpyxl/issue/451>`_ fitToPage setting ignored
+* `#458 <https://bitbucket.org/openpyxl/openpyxl/issue/458>`_ Trailing spaces lost when saving files.
+* `#459 <https://bitbucket.org/openpyxl/openpyxl/issue/459>`_ setup.py install fails with Python 3
+* `#462 <https://bitbucket.org/openpyxl/openpyxl/issue/462>`_ Vestigial rId conflicts when adding charts, images or comments
+* `#455 <https://bitbucket.org/openpyxl/openpyxl/issue/455>`_ Enable Zip64 extensions for all versions of Python
 
 
 2.2.2 (2015-04-28)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#447 <https://bitbucket.org/fastpyxl/fastpyxl/issue/447>`_ Uppercase datetime number formats not recognised.
-* `#453 <https://bitbucket.org/fastpyxl/fastpyxl/issue/453>`_ Borders broken in shared_styles.
+* `#447 <https://bitbucket.org/openpyxl/openpyxl/issue/447>`_ Uppercase datetime number formats not recognised.
+* `#453 <https://bitbucket.org/openpyxl/openpyxl/issue/453>`_ Borders broken in shared_styles.
 
 
 2.2.1 (2015-03-31)
-==================
+------------------
 
 
 Minor changes
 -------------
 
-* `PR54 <https://bitbucket.org/fastpyxl/fastpyxl/pull-request/54>`_ Improved precision on times near midnight.
-* `PR55 <https://bitbucket.org/fastpyxl/fastpyxl/pull-request/55>`_ Preserve macro buttons
+* `PR54 <https://bitbucket.org/openpyxl/openpyxl/pull-request/54>`_ Improved precision on times near midnight.
+* `PR55 <https://bitbucket.org/openpyxl/openpyxl/pull-request/55>`_ Preserve macro buttons
 
 
 Bug fixes
 ---------
 
-* `#429 <https://bitbucket.org/fastpyxl/fastpyxl/issue/429>`_ Workbook fails to load because header and footers cannot be parsed.
-* `#433 <https://bitbucket.org/fastpyxl/fastpyxl/issue/433>`_ File-like object with encoding=None
-* `#434 <https://bitbucket.org/fastpyxl/fastpyxl/issue/434>`_ SyntaxError when writing page breaks.
-* `#436 <https://bitbucket.org/fastpyxl/fastpyxl/issue/436>`_ Read-only mode duplicates empty rows.
-* `#437 <https://bitbucket.org/fastpyxl/fastpyxl/issue/437>`_ Cell.offset raises an exception
-* `#438 <https://bitbucket.org/fastpyxl/fastpyxl/issue/438>`_ Cells with pivotButton and quotePrefix styles cannot be read
-* `#440 <https://bitbucket.org/fastpyxl/fastpyxl/issue/440>`_ Error when customised versions of builtin formats
-* `#442 <https://bitbucket.org/fastpyxl/fastpyxl/issue/442>`_ Exception raised when a fill element contains no children
-* `#444 <https://bitbucket.org/fastpyxl/fastpyxl/issue/442>`_ Styles cannot be copied
+* `#429 <https://bitbucket.org/openpyxl/openpyxl/issue/429>`_ Workbook fails to load because header and footers cannot be parsed.
+* `#433 <https://bitbucket.org/openpyxl/openpyxl/issue/433>`_ File-like object with encoding=None
+* `#434 <https://bitbucket.org/openpyxl/openpyxl/issue/434>`_ SyntaxError when writing page breaks.
+* `#436 <https://bitbucket.org/openpyxl/openpyxl/issue/436>`_ Read-only mode duplicates empty rows.
+* `#437 <https://bitbucket.org/openpyxl/openpyxl/issue/437>`_ Cell.offset raises an exception
+* `#438 <https://bitbucket.org/openpyxl/openpyxl/issue/438>`_ Cells with pivotButton and quotePrefix styles cannot be read
+* `#440 <https://bitbucket.org/openpyxl/openpyxl/issue/440>`_ Error when customised versions of builtin formats
+* `#442 <https://bitbucket.org/openpyxl/openpyxl/issue/442>`_ Exception raised when a fill element contains no children
+* `#444 <https://bitbucket.org/openpyxl/openpyxl/issue/442>`_ Styles cannot be copied
 
 
 2.2.0 (2015-03-11)
-==================
+------------------
 
 
 Bug fixes
 ---------
-* `#415 <https://bitbucket.org/fastpyxl/fastpyxl/issue/415>`_ Improved exception when passing in invalid in memory files.
+* `#415 <https://bitbucket.org/openpyxl/openpyxl/issue/415>`_ Improved exception when passing in invalid in memory files.
 
 
 2.2.0-b1 (2015-02-18)
-=====================
+---------------------
 
 
 Major changes
@@ -1392,43 +1403,43 @@ Major changes
 * Charts will no longer try and calculate axes by default
 * Support for template file types - PR21
 * Moved ancillary functions and classes into utils package - single place of reference
-* `PR 34 <https://bitbucket.org/fastpyxl/fastpyxl/pull-request/34/>`_ Fully support page setup
+* `PR 34 <https://bitbucket.org/openpyxl/openpyxl/pull-request/34/>`_ Fully support page setup
 * Removed SAX-based XML Generator. Special thanks to Elias Rabel for implementing xmlfile for xml.etree
 * Preserve sheet view definitions in existing files (frozen panes, zoom, etc.)
 
 
 Bug fixes
 ---------
-* `#103 <https://bitbucket.org/fastpyxl/fastpyxl/issue/103>`_ Set the zoom of a sheet
-* `#199 <https://bitbucket.org/fastpyxl/fastpyxl/issue/199>`_ Hide gridlines
-* `#215 <https://bitbucket.org/fastpyxl/fastpyxl/issue/215>`_ Preserve sheet view setings
-* `#262 <https://bitbucket.org/fastpyxl/fastpyxl/issue/262>`_ Set the zoom of a sheet
-* `#392 <https://bitbucket.org/fastpyxl/fastpyxl/issue/392>`_ Worksheet header not read
-* `#387 <https://bitbucket.org/fastpyxl/fastpyxl/issue/387>`_ Cannot read files without styles.xml
-* `#410 <https://bitbucket.org/fastpyxl/fastpyxl/issue/410>`_ Exception when preserving whitespace in strings
-* `#417 <https://bitbucket.org/fastpyxl/fastpyxl/issue/417>`_ Cannot create print titles
-* `#420 <https://bitbucket.org/fastpyxl/fastpyxl/issue/420>`_ Rename confusing constants
-* `#422 <https://bitbucket.org/fastpyxl/fastpyxl/issue/422>`_ Preserve color index in a workbook if it differs from the standard
+* `#103 <https://bitbucket.org/openpyxl/openpyxl/issue/103>`_ Set the zoom of a sheet
+* `#199 <https://bitbucket.org/openpyxl/openpyxl/issue/199>`_ Hide gridlines
+* `#215 <https://bitbucket.org/openpyxl/openpyxl/issue/215>`_ Preserve sheet view setings
+* `#262 <https://bitbucket.org/openpyxl/openpyxl/issue/262>`_ Set the zoom of a sheet
+* `#392 <https://bitbucket.org/openpyxl/openpyxl/issue/392>`_ Worksheet header not read
+* `#387 <https://bitbucket.org/openpyxl/openpyxl/issue/387>`_ Cannot read files without styles.xml
+* `#410 <https://bitbucket.org/openpyxl/openpyxl/issue/410>`_ Exception when preserving whitespace in strings
+* `#417 <https://bitbucket.org/openpyxl/openpyxl/issue/417>`_ Cannot create print titles
+* `#420 <https://bitbucket.org/openpyxl/openpyxl/issue/420>`_ Rename confusing constants
+* `#422 <https://bitbucket.org/openpyxl/openpyxl/issue/422>`_ Preserve color index in a workbook if it differs from the standard
 
 
 Minor changes
 -------------
 * Use a 2-way cache for column index lookups
 * Clean up tests in cells
-* `PR 40 <https://bitbucket.org/fastpyxl/fastpyxl/pull-request/40/>`_ Support frozen panes and autofilter in write-only mode
+* `PR 40 <https://bitbucket.org/openpyxl/openpyxl/pull-request/40/>`_ Support frozen panes and autofilter in write-only mode
 * Use ws.calculate_dimension(force=True) in read-only mode for unsized worksheets
 
 
 2.1.5 (2015-02-18)
-==================
+------------------
 
 
 Bug fixes
 ---------
-* `#403 <https://bitbucket.org/fastpyxl/fastpyxl/issue/403>`_ Cannot add comments in write-only mode
-* `#401 <https://bitbucket.org/fastpyxl/fastpyxl/issue/401>`_ Creating cells in an empty row raises an exception
-* `#408 <https://bitbucket.org/fastpyxl/fastpyxl/issue/408>`_ from_excel adjustment for Julian dates 1 < x < 60
-* `#409 <https://bitbucket.org/fastpyxl/fastpyxl/issue/409>`_ refersTo is an optional attribute
+* `#403 <https://bitbucket.org/openpyxl/openpyxl/issue/403>`_ Cannot add comments in write-only mode
+* `#401 <https://bitbucket.org/openpyxl/openpyxl/issue/401>`_ Creating cells in an empty row raises an exception
+* `#408 <https://bitbucket.org/openpyxl/openpyxl/issue/408>`_ from_excel adjustment for Julian dates 1 < x < 60
+* `#409 <https://bitbucket.org/openpyxl/openpyxl/issue/409>`_ refersTo is an optional attribute
 
 
 Minor changes
@@ -1437,17 +1448,17 @@ Minor changes
 
 
 2.1.4 (2014-12-16)
-==================
+------------------
 
 
 Bug fixes
 ---------
 
-* `#393 <https://bitbucket.org/fastpyxl/fastpyxl/issue/393>`_ IterableWorksheet skips empty cells in rows
-* `#394 <https://bitbucket.org/fastpyxl/fastpyxl/issue/394>`_ Date format is applied to all columns (while only first column contains dates)
-* `#395 <https://bitbucket.org/fastpyxl/fastpyxl/issue/395>`_ temporary files not cleaned properly
-* `#396 <https://bitbucket.org/fastpyxl/fastpyxl/issue/396>`_ Cannot write "=" in Excel file
-* `#398 <https://bitbucket.org/fastpyxl/fastpyxl/issue/398>`_ Cannot write empty rows in write-only mode with LXML installed
+* `#393 <https://bitbucket.org/openpyxl/openpyxl/issue/393>`_ IterableWorksheet skips empty cells in rows
+* `#394 <https://bitbucket.org/openpyxl/openpyxl/issue/394>`_ Date format is applied to all columns (while only first column contains dates)
+* `#395 <https://bitbucket.org/openpyxl/openpyxl/issue/395>`_ temporary files not cleaned properly
+* `#396 <https://bitbucket.org/openpyxl/openpyxl/issue/396>`_ Cannot write "=" in Excel file
+* `#398 <https://bitbucket.org/openpyxl/openpyxl/issue/398>`_ Cannot write empty rows in write-only mode with LXML installed
 
 
 Minor changes
@@ -1457,42 +1468,42 @@ Minor changes
 
 
 2.1.3 (2014-12-09)
-==================
+------------------
 
 
 Minor changes
 -------------
-* `PR 31 <https://bitbucket.org/fastpyxl/fastpyxl/pull-request/31/>`_ Correct tutorial
-* `PR 32 <https://bitbucket.org/fastpyxl/fastpyxl/pull-request/32/>`_ See #380
-* `PR 37 <https://bitbucket.org/fastpyxl/fastpyxl/pull-request/37/>`_ Bind worksheet to ColumnDimension objects
+* `PR 31 <https://bitbucket.org/openpyxl/openpyxl/pull-request/31/>`_ Correct tutorial
+* `PR 32 <https://bitbucket.org/openpyxl/openpyxl/pull-request/32/>`_ See #380
+* `PR 37 <https://bitbucket.org/openpyxl/openpyxl/pull-request/37/>`_ Bind worksheet to ColumnDimension objects
 
 
 Bug fixes
 ---------
-* `#379 <https://bitbucket.org/fastpyxl/fastpyxl/issue/379>`_ ws.append() doesn't set RowDimension Correctly
-* `#380 <https://bitbucket.org/fastpyxl/fastpyxl/issue/379>`_ empty cells formatted as datetimes raise exceptions
+* `#379 <https://bitbucket.org/openpyxl/openpyxl/issue/379>`_ ws.append() doesn't set RowDimension Correctly
+* `#380 <https://bitbucket.org/openpyxl/openpyxl/issue/379>`_ empty cells formatted as datetimes raise exceptions
 
 
 2.1.2 (2014-10-23)
-==================
+------------------
 
 
 Minor changes
 -------------
-* `PR 30 <https://bitbucket.org/fastpyxl/fastpyxl/pull-request/30/>`_ Fix regex for positive exponentials
-* `PR 28 <https://bitbucket.org/fastpyxl/fastpyxl/pull-request/28/>`_ Fix for #328
+* `PR 30 <https://bitbucket.org/openpyxl/openpyxl/pull-request/30/>`_ Fix regex for positive exponentials
+* `PR 28 <https://bitbucket.org/openpyxl/openpyxl/pull-request/28/>`_ Fix for #328
 
 
 Bug fixes
 ---------
-* `#120 <https://bitbucket.org/fastpyxl/fastpyxl/issue/120>`_, `#168 <https://bitbucket.org/fastpyxl/fastpyxl/issue/168>`_ defined names with formulae raise exceptions, `#292 <https://bitbucket.org/fastpyxl/fastpyxl/issue/292>`_
-* `#328 <https://bitbucket.org/fastpyxl/fastpyxl/issue/328/>`_ ValueError when reading cells with hyperlinks
-* `#369 <https://bitbucket.org/fastpyxl/fastpyxl/issue/369>`_ IndexError when reading definedNames
-* `#372 <https://bitbucket.org/fastpyxl/fastpyxl/issue/372>`_ number_format not consistently applied from styles
+* `#120 <https://bitbucket.org/openpyxl/openpyxl/issue/120>`_, `#168 <https://bitbucket.org/openpyxl/openpyxl/issue/168>`_ defined names with formulae raise exceptions, `#292 <https://bitbucket.org/openpyxl/openpyxl/issue/292>`_
+* `#328 <https://bitbucket.org/openpyxl/openpyxl/issue/328/>`_ ValueError when reading cells with hyperlinks
+* `#369 <https://bitbucket.org/openpyxl/openpyxl/issue/369>`_ IndexError when reading definedNames
+* `#372 <https://bitbucket.org/openpyxl/openpyxl/issue/372>`_ number_format not consistently applied from styles
 
 
 2.1.1 (2014-10-08)
-==================
+------------------
 
 
 Minor changes
@@ -1504,16 +1515,16 @@ Minor changes
 Bug fixes
 ---------
 
-* `#332 <https://bitbucket.org/fastpyxl/fastpyxl/issue/332>`_ Fills lost in ConditionalFormatting
-* `#360 <https://bitbucket.org/fastpyxl/fastpyxl/issue/360>`_ Support value="none" in attributes
-* `#363 <https://bitbucket.org/fastpyxl/fastpyxl/issue/363>`_ Support undocumented value for textRotation
-* `#364 <https://bitbucket.org/fastpyxl/fastpyxl/issue/364>`_ Preserve integers in read-only mode
-* `#366 <https://bitbucket.org/fastpyxl/fastpyxl/issue/366>`_ Complete read support for DataValidation
-* `#367 <https://bitbucket.org/fastpyxl/fastpyxl/issue/367>`_ Iterate over unsized worksheets
+* `#332 <https://bitbucket.org/openpyxl/openpyxl/issue/332>`_ Fills lost in ConditionalFormatting
+* `#360 <https://bitbucket.org/openpyxl/openpyxl/issue/360>`_ Support value="none" in attributes
+* `#363 <https://bitbucket.org/openpyxl/openpyxl/issue/363>`_ Support undocumented value for textRotation
+* `#364 <https://bitbucket.org/openpyxl/openpyxl/issue/364>`_ Preserve integers in read-only mode
+* `#366 <https://bitbucket.org/openpyxl/openpyxl/issue/366>`_ Complete read support for DataValidation
+* `#367 <https://bitbucket.org/openpyxl/openpyxl/issue/367>`_ Iterate over unsized worksheets
 
 
 2.1.0 (2014-09-21)
-==================
+------------------
 
 Major changes
 -------------
@@ -1539,28 +1550,28 @@ Minor changes
 
 Bug fixes
 ---------
-* `#153 <https://bitbucket.org/fastpyxl/fastpyxl/issue/153>`_ Cannot read visibility of sheets and rows
-* `#181 <https://bitbucket.org/fastpyxl/fastpyxl/issue/181>`_ No content type for worksheets
-* `241 <https://bitbucket.org/fastpyxl/fastpyxl/issue/241>`_ Cannot read sheets with inline strings
-* `322 <https://bitbucket.org/fastpyxl/fastpyxl/issue/322>`_ 1-indexing for merged cells
-* `339 <https://bitbucket.org/fastpyxl/fastpyxl/issue/339>`_ Correctly handle removal of cell protection
-* `341 <https://bitbucket.org/fastpyxl/fastpyxl/issue/341>`_ Cells with formulae do not round-trip
-* `347 <https://bitbucket.org/fastpyxl/fastpyxl/issue/347>`_ Read DataValidations
-* `353 <https://bitbucket.org/fastpyxl/fastpyxl/issue/353>`_ Support Defined Named Ranges to external workbooks
+* `#153 <https://bitbucket.org/openpyxl/openpyxl/issue/153>`_ Cannot read visibility of sheets and rows
+* `#181 <https://bitbucket.org/openpyxl/openpyxl/issue/181>`_ No content type for worksheets
+* `241 <https://bitbucket.org/openpyxl/openpyxl/issue/241>`_ Cannot read sheets with inline strings
+* `322 <https://bitbucket.org/openpyxl/openpyxl/issue/322>`_ 1-indexing for merged cells
+* `339 <https://bitbucket.org/openpyxl/openpyxl/issue/339>`_ Correctly handle removal of cell protection
+* `341 <https://bitbucket.org/openpyxl/openpyxl/issue/341>`_ Cells with formulae do not round-trip
+* `347 <https://bitbucket.org/openpyxl/openpyxl/issue/347>`_ Read DataValidations
+* `353 <https://bitbucket.org/openpyxl/openpyxl/issue/353>`_ Support Defined Named Ranges to external workbooks
 
 
 2.0.5 (2014-08-08)
-==================
+------------------
 
 
 Bug fixes
 ---------
-* `#348 <https://bitbucket.org/fastpyxl/fastpyxl/issue/348>`_ incorrect casting of boolean strings
-* `#349 <https://bitbucket.org/fastpyxl/fastpyxl/issue/349>`_ roundtripping cells with formulae
+* `#348 <https://bitbucket.org/openpyxl/openpyxl/issue/348>`_ incorrect casting of boolean strings
+* `#349 <https://bitbucket.org/openpyxl/openpyxl/issue/349>`_ roundtripping cells with formulae
 
 
 2.0.4 (2014-06-25)
-==================
+------------------
 
 Minor changes
 -------------
@@ -1570,12 +1581,12 @@ Minor changes
 Bug fixes
 ---------
 
-* `#331 <https://bitbucket.org/fastpyxl/fastpyxl/issue/331>`_ DARKYELLOW was incorrect
+* `#331 <https://bitbucket.org/openpyxl/openpyxl/issue/331>`_ DARKYELLOW was incorrect
 * Correctly handle extend attribute for fonts
 
 
 2.0.3 (2014-05-22)
-==================
+------------------
 
 Minor changes
 -------------
@@ -1586,17 +1597,17 @@ Minor changes
 Bug fixes
 ---------
 
-* `#319 <https://bitbucket.org/fastpyxl/fastpyxl/issue/319>`_ Cannot load Workbooks with vertAlign styling for fonts
+* `#319 <https://bitbucket.org/openpyxl/openpyxl/issue/319>`_ Cannot load Workbooks with vertAlign styling for fonts
 
 
 2.0.2 (2014-05-13)
-==================
+------------------
 
 2.0.1 (2014-05-13)  brown bag
-=============================
+-----------------------------
 
 2.0.0 (2014-05-13)  brown bag
-=============================
+-----------------------------
 
 
 Major changes
@@ -1635,29 +1646,29 @@ Pull requests
 
 Bug fixes
 ---------
-* `#46 <https://bitbucket.org/fastpyxl/fastpyxl/issue/46>`_ ColumnDimension style error
-* `#86 <https://bitbucket.org/fastpyxl/fastpyxl/issue/86>`_ reader.worksheet.fast_parse sets booleans to integers
-* `#98 <https://bitbucket.org/fastpyxl/fastpyxl/issue/98>`_ Auto sizing column widths does not work
-* `#137 <https://bitbucket.org/fastpyxl/fastpyxl/issue/137>`_ Workbooks with chartsheets
-* `#185 <https://bitbucket.org/fastpyxl/fastpyxl/issue/185>`_  Invalid PageMargins
-* `#230 <https://bitbucket.org/fastpyxl/fastpyxl/issue/230>`_ Using \v in cells creates invalid files
-* `#243 <https://bitbucket.org/fastpyxl/fastpyxl/issue/243>`_ - IndexError when loading workbook
-* `#263 <https://bitbucket.org/fastpyxl/fastpyxl/issue/263>`_ - Forded conversion of line breaks
-* `#267 <https://bitbucket.org/fastpyxl/fastpyxl/issue/267>`_ - Raise exceptions when passed invalid types
-* `#270 <https://bitbucket.org/fastpyxl/fastpyxl/issue/270>`_ - Cannot open files which use non-standard sheet names or reference Ids
-* `#269 <https://bitbucket.org/fastpyxl/fastpyxl/issue/269>`_ - Handling unsized worksheets in IterableWorksheet
-* `#270 <https://bitbucket.org/fastpyxl/fastpyxl/issue/270>`_ - Handling Workbooks with non-standard references
-* `#275 <https://bitbucket.org/fastpyxl/fastpyxl/issue/275>`_ - Handling auto filters where there are only custom filters
-* `#277 <https://bitbucket.org/fastpyxl/fastpyxl/issue/277>`_ - Harmonise chart and cell coordinates
-* `#280 <https://bitbucket.org/fastpyxl/fastpyxl/issue/280>`_- Explicit exception raising for invalid characters
-* `#286 <https://bitbucket.org/fastpyxl/fastpyxl/issue/286>`_ - Optimized writer can not handle a datetime.time value
-* `#296 <https://bitbucket.org/fastpyxl/fastpyxl/issue/296>`_ - Cell coordinates not consistent with documentation
-* `#300 <https://bitbucket.org/fastpyxl/fastpyxl/issue/300>`_ - Missing column width causes load_workbook() exception
-* `#304 <https://bitbucket.org/fastpyxl/fastpyxl/issue/304>`_ - Handling Workbooks with absolute paths for worksheets (from Sharepoint)
+* `#46 <https://bitbucket.org/openpyxl/openpyxl/issue/46>`_ ColumnDimension style error
+* `#86 <https://bitbucket.org/openpyxl/openpyxl/issue/86>`_ reader.worksheet.fast_parse sets booleans to integers
+* `#98 <https://bitbucket.org/openpyxl/openpyxl/issue/98>`_ Auto sizing column widths does not work
+* `#137 <https://bitbucket.org/openpyxl/openpyxl/issue/137>`_ Workbooks with chartsheets
+* `#185 <https://bitbucket.org/openpyxl/openpyxl/issue/185>`_  Invalid PageMargins
+* `#230 <https://bitbucket.org/openpyxl/openpyxl/issue/230>`_ Using \v in cells creates invalid files
+* `#243 <https://bitbucket.org/openpyxl/openpyxl/issue/243>`_ - IndexError when loading workbook
+* `#263 <https://bitbucket.org/openpyxl/openpyxl/issue/263>`_ - Forded conversion of line breaks
+* `#267 <https://bitbucket.org/openpyxl/openpyxl/issue/267>`_ - Raise exceptions when passed invalid types
+* `#270 <https://bitbucket.org/openpyxl/openpyxl/issue/270>`_ - Cannot open files which use non-standard sheet names or reference Ids
+* `#269 <https://bitbucket.org/openpyxl/openpyxl/issue/269>`_ - Handling unsized worksheets in IterableWorksheet
+* `#270 <https://bitbucket.org/openpyxl/openpyxl/issue/270>`_ - Handling Workbooks with non-standard references
+* `#275 <https://bitbucket.org/openpyxl/openpyxl/issue/275>`_ - Handling auto filters where there are only custom filters
+* `#277 <https://bitbucket.org/openpyxl/openpyxl/issue/277>`_ - Harmonise chart and cell coordinates
+* `#280 <https://bitbucket.org/openpyxl/openpyxl/issue/280>`_- Explicit exception raising for invalid characters
+* `#286 <https://bitbucket.org/openpyxl/openpyxl/issue/286>`_ - Optimized writer can not handle a datetime.time value
+* `#296 <https://bitbucket.org/openpyxl/openpyxl/issue/296>`_ - Cell coordinates not consistent with documentation
+* `#300 <https://bitbucket.org/openpyxl/openpyxl/issue/300>`_ - Missing column width causes load_workbook() exception
+* `#304 <https://bitbucket.org/openpyxl/openpyxl/issue/304>`_ - Handling Workbooks with absolute paths for worksheets (from Sharepoint)
 
 
 1.8.6 (2014-05-05)
-==================
+------------------
 
 Minor changes
 -------------
@@ -1665,11 +1676,11 @@ Fixed typo for import Elementtree
 
 Bugfixes
 --------
-* `#279 <https://bitbucket.org/fastpyxl/fastpyxl/issue/279>`_ Incorrect path for comments files on Windows
+* `#279 <https://bitbucket.org/openpyxl/openpyxl/issue/279>`_ Incorrect path for comments files on Windows
 
 
 1.8.5 (2014-03-25)
-==================
+------------------
 
 Minor changes
 -------------
@@ -1678,17 +1689,17 @@ Minor changes
 
 
 1.8.4 (2014-02-25)
-==================
+------------------
 
 Bugfixes
 --------
-* `#260 <https://bitbucket.org/fastpyxl/fastpyxl/issue/260>`_ better handling of undimensioned worksheets
-* `#268 <https://bitbucket.org/fastpyxl/fastpyxl/issue/268>`_ non-ascii in formualae
-* `#282 <https://bitbucket.org/fastpyxl/fastpyxl/issue/282>`_ correct implementation of register_namepsace for Python 2.6
+* `#260 <https://bitbucket.org/openpyxl/openpyxl/issue/260>`_ better handling of undimensioned worksheets
+* `#268 <https://bitbucket.org/openpyxl/openpyxl/issue/268>`_ non-ascii in formualae
+* `#282 <https://bitbucket.org/openpyxl/openpyxl/issue/282>`_ correct implementation of register_namepsace for Python 2.6
 
 
 1.8.3 (2014-02-09)
-==================
+------------------
 
 Major changes
 -------------
@@ -1698,27 +1709,27 @@ Minor changes
 -------------
 Slight improvements in memory use when parsing
 
-* `#256 <https://bitbucket.org/fastpyxl/fastpyxl/issue/256>`_ - error when trying to read comments with optimised reader
-* `#260 <https://bitbucket.org/fastpyxl/fastpyxl/issue/260>`_ - unsized worksheets
-* `#264 <https://bitbucket.org/fastpyxl/fastpyxl/issue/264>`_ - only numeric cells can be dates
+* `#256 <https://bitbucket.org/openpyxl/openpyxl/issue/256>`_ - error when trying to read comments with optimised reader
+* `#260 <https://bitbucket.org/openpyxl/openpyxl/issue/260>`_ - unsized worksheets
+* `#264 <https://bitbucket.org/openpyxl/openpyxl/issue/264>`_ - only numeric cells can be dates
 
 
 1.8.2 (2014-01-17)
-==================
+------------------
 
-* `#247 <https://bitbucket.org/fastpyxl/fastpyxl/issue/247>`_ - iterable worksheets open too many files
-* `#252 <https://bitbucket.org/fastpyxl/fastpyxl/issue/252>`_ - improved handling of lxml
-* `#253 <https://bitbucket.org/fastpyxl/fastpyxl/issue/253>`_ - better handling of unique sheetnames
+* `#247 <https://bitbucket.org/openpyxl/openpyxl/issue/247>`_ - iterable worksheets open too many files
+* `#252 <https://bitbucket.org/openpyxl/openpyxl/issue/252>`_ - improved handling of lxml
+* `#253 <https://bitbucket.org/openpyxl/openpyxl/issue/253>`_ - better handling of unique sheetnames
 
 
 1.8.1 (2014-01-14)
-==================
+------------------
 
-* `#246 <https://bitbucket.org/fastpyxl/fastpyxl/issue/246>`_
+* `#246 <https://bitbucket.org/openpyxl/openpyxl/issue/246>`_
 
 
 1.8.0 (2014-01-08)
-==================
+------------------
 
 Compatibility
 -------------
@@ -1747,7 +1758,7 @@ Minor changes
 
 
 1.7.0 (2013-10-31)
-==================
+------------------
 
 
 Major changes
@@ -1781,15 +1792,15 @@ Merged pull requests
 Known bugfixes
 --------------
 
-* `#109 <https://bitbucket.org/fastpyxl/fastpyxl/issue/109>`_
-* `#165 <https://bitbucket.org/fastpyxl/fastpyxl/issue/165>`_
-* `#209 <https://bitbucket.org/fastpyxl/fastpyxl/issue/209>`_
-* `#112 <https://bitbucket.org/fastpyxl/fastpyxl/issue/112>`_
-* `#166 <https://bitbucket.org/fastpyxl/fastpyxl/issue/166>`_
-* `#109 <https://bitbucket.org/fastpyxl/fastpyxl/issue/109>`_
-* `#223 <https://bitbucket.org/fastpyxl/fastpyxl/issue/223>`_
-* `#124 <https://bitbucket.org/fastpyxl/fastpyxl/issue/124>`_
-* `#157 <https://bitbucket.org/fastpyxl/fastpyxl/issue/157>`_
+* `#109 <https://bitbucket.org/openpyxl/openpyxl/issue/109>`_
+* `#165 <https://bitbucket.org/openpyxl/openpyxl/issue/165>`_
+* `#209 <https://bitbucket.org/openpyxl/openpyxl/issue/209>`_
+* `#112 <https://bitbucket.org/openpyxl/openpyxl/issue/112>`_
+* `#166 <https://bitbucket.org/openpyxl/openpyxl/issue/166>`_
+* `#109 <https://bitbucket.org/openpyxl/openpyxl/issue/109>`_
+* `#223 <https://bitbucket.org/openpyxl/openpyxl/issue/223>`_
+* `#124 <https://bitbucket.org/openpyxl/openpyxl/issue/124>`_
+* `#157 <https://bitbucket.org/openpyxl/openpyxl/issue/157>`_
 
 
 Miscellaneous

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -143,7 +143,7 @@ else:
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = 'logo.png'
+html_logo = 'logo.svg'
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,9 +2,9 @@ fastpyxl - A high-performance Python library to read/write Excel 2010 xlsx/xlsm 
 ======================================================================================
 
 
-:Author: Eric Gazoni, Charlie Clark
-:Source code: https://github.com/fastpyxl/fastpyxl
-:Issues: https://github.com/fastpyxl/fastpyxl/issues
+:Author: Christopher C. Smith
+:Source code: https://github.com/Promptly-Technologies-LLC/fastpyxl
+:Issues: https://github.com/Promptly-Technologies-LLC/fastpyxl/issues
 :Generated: |today|
 :License: MIT/Expat
 :Version: |release|
@@ -16,24 +16,9 @@ fastpyxl - A high-performance Python library to read/write Excel 2010 xlsx/xlsm 
 Support
 -------
 
-This is an open source project, maintained by volunteers in their spare time.
-This may well mean that particular features or functions that you would like
-are missing. But things don't have to stay that way. You can contribute the
-project :doc:`development` yourself or contract a developer for particular
-features.
-
-
-Professional support for fastpyxl is available from
-`Clark Consulting & Research <http://www.clark-consulting.eu/>`_ and
-`Adimian <http://www.adimian.com>`_. Donations to the project to support further
-development and maintenance are welcome.
-
-
 Bug reports and feature requests should be submitted using the `issue tracker
-<https://github.com/fastpyxl/fastpyxl/issues>`_. Please provide a full
-traceback of any error you see and if possible a sample file. If for reasons
-of confidentiality you are unable to make a file publicly available then
-contact of one the developers.
+<https://github.com/Promptly-Technologies-LLC/fastpyxl/issues>`_. Please
+provide a full traceback of any error you see and if possible a sample file.
 
 
 How to Contribute
@@ -42,9 +27,10 @@ How to Contribute
 Any help will be greatly appreciated, just follow those steps:
 
     1.
-    `Fork the repository <https://github.com/fastpyxl/fastpyxl/fork>`_ on GitHub and create a branch
-    for each independent feature; don't try to fix all problems at the same
-    time, it's easier for those who will review and merge your changes ;-)
+    `Fork the repository <https://github.com/Promptly-Technologies-LLC/fastpyxl/fork>`_
+    on GitHub and create a branch for each independent feature; don't try to
+    fix all problems at the same time, it's easier for those who will review
+    and merge your changes ;-)
 
     2.
     Hack hack hack
@@ -56,7 +42,7 @@ Any help will be greatly appreciated, just follow those steps:
 
     4.
     If you added a whole new feature, or just improved something, you can
-    be proud of it, so add yourself to the AUTHORS file :-)
+    be proud of it, so add yourself to the git history :-)
 
     5.
     Let people know about the shiny thing you just implemented, update the

--- a/doc/logo.svg
+++ b/doc/logo.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 80" width="360" height="80">
+  <defs>
+    <linearGradient id="speed" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1a7f37"/>
+      <stop offset="100%" stop-color="#2ea043"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2ea043"/>
+      <stop offset="100%" stop-color="#56d364"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Speed lines -->
+  <rect x="12" y="28" width="22" height="3" rx="1.5" fill="#2ea043" opacity="0.3"/>
+  <rect x="8" y="38" width="28" height="3" rx="1.5" fill="#2ea043" opacity="0.5"/>
+  <rect x="14" y="48" width="20" height="3" rx="1.5" fill="#2ea043" opacity="0.3"/>
+
+  <!-- Spreadsheet grid icon -->
+  <rect x="38" y="18" width="44" height="44" rx="4" fill="url(#speed)" stroke="none"/>
+  <!-- Grid lines -->
+  <line x1="38" y1="34" x2="82" y2="34" stroke="white" stroke-width="1.5" opacity="0.5"/>
+  <line x1="38" y1="46" x2="82" y2="46" stroke="white" stroke-width="1.5" opacity="0.5"/>
+  <line x1="54" y1="18" x2="54" y2="62" stroke="white" stroke-width="1.5" opacity="0.5"/>
+  <line x1="68" y1="18" x2="68" y2="62" stroke="white" stroke-width="1.5" opacity="0.5"/>
+  <!-- Lightning bolt in center cell -->
+  <polygon points="62,36 57,45 60,45 58,54 65,43 62,43 64,36" fill="#ffd33d"/>
+
+  <!-- Text: "fast" in bold -->
+  <text x="96" y="54" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="38" font-weight="700" fill="#24292f" letter-spacing="-1">fast</text>
+  <!-- Text: "pyxl" in regular weight -->
+  <text x="192" y="54" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="38" font-weight="400" fill="#57606a" letter-spacing="-1">pyxl</text>
+</svg>

--- a/fastpyxl/_constants.py
+++ b/fastpyxl/_constants.py
@@ -1,13 +1,14 @@
-# Copyright (c) 2010-2024 fastpyxl
+# Copyright (c) 2010-2024 openpyxl contributors
+# Copyright (c) 2024-2026 Christopher C. Smith
 
 """
 Package metadata
 """
 
-__author__ = "See AUTHORS"
-__author_email__ = "charlie.clark@clark-consulting.eu"
+__author__ = "Christopher C. Smith"
+__author_email__ = "christopher.smith@promptlytechnologies.com"
 __license__ = "MIT"
-__maintainer_email__ = "fastpyxl-users@googlegroups.com"
+__maintainer_email__ = "christopher.smith@promptlytechnologies.com"
 __url__ = "https://fastpyxl.readthedocs.io"
 __version__ = "1.0.0"
-__python__ = "3.8"
+__python__ = "3.11"


### PR DESCRIPTION
## Summary
- Update author, email, and copyright to Christopher C. Smith / Promptly Technologies
- Fix all GitHub and Bitbucket issue links in changelog to point to original openpyxl repos
- Add changelog header clarifying inherited openpyxl history, with link to fastpyxl releases
- Replace openpyxl logo with new fastpyxl SVG logo (spreadsheet grid + lightning bolt)
- Remove Clark Consulting & Adimian professional support references
- Update all contributing/issue/fork URLs to `Promptly-Technologies-LLC/fastpyxl`
- Bump `__python__` from 3.8 to 3.11

## Test plan
- [ ] Verify Sphinx docs build locally with `cd doc && make html`
- [ ] Verify logo renders correctly in built docs
- [ ] Spot-check changelog links resolve to openpyxl repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)