### PR TITLE
fix: derive workbook content type from filename extension (fixes #46)

### DIFF
--- a/fastpyxl/packaging/manifest.py
+++ b/fastpyxl/packaging/manifest.py
@@ -170,11 +170,19 @@ class Manifest(Serialisable):
         self._append_override_if_missing(ct)
 
 
-    def _write(self, archive, workbook):
+    def _write(self, archive, workbook, workbook_mime_type=None):
         """
-        Write manifest to the archive
+        Write manifest to the archive.
+
+        When ``workbook_mime_type`` is supplied it overrides the workbook's
+        own ``mime_type`` — used so the ``[Content_Types].xml`` entry matches
+        the output file's extension (e.g. ``.xlsm`` → macro-enabled).
         """
-        self.append(workbook)
+        if workbook_mime_type:
+            ct = Override(PartName=workbook.path, ContentType=workbook_mime_type)
+            self._append_override_if_missing(ct)
+        else:
+            self.append(workbook)
         self._write_vba(workbook)
         self._register_mimetypes(filenames=archive.namelist())
         archive.writestr(self.path, tostring(self.to_tree()))

--- a/fastpyxl/writer/excel.py
+++ b/fastpyxl/writer/excel.py
@@ -3,6 +3,7 @@
 
 # Python stdlib imports
 import datetime
+import os
 import re
 from zipfile import ZipFile, ZIP_DEFLATED
 
@@ -18,6 +19,10 @@ from fastpyxl.xml.constants import (
     ARC_THEME,
     ARC_STYLE,
     ARC_WORKBOOK,
+    XLSM,
+    XLSX,
+    XLTM,
+    XLTX,
     )
 from fastpyxl.drawing.spreadsheet_drawing import SpreadsheetDrawing
 from fastpyxl.xml.functions import tostring, fromstring
@@ -39,10 +44,28 @@ ARC_VBA = re.compile("|".join(
 ))
 
 
+_EXT_MIME_MAP = {
+    '.xlsx': XLSX,
+    '.xlsm': XLSM,
+    '.xltx': XLTX,
+    '.xltm': XLTM,
+}
+
+
+def _mime_type_from_filename(filename):
+    if filename is None:
+        return None
+    name = getattr(filename, 'name', filename)
+    if not isinstance(name, (str, bytes, os.PathLike)):
+        return None
+    ext = os.path.splitext(os.fspath(name))[1].lower()
+    return _EXT_MIME_MAP.get(ext)
+
+
 class ExcelWriter:
     """Write a workbook object to an Excel file."""
 
-    def __init__(self, workbook, archive):
+    def __init__(self, workbook, archive, workbook_mime_type=None):
         self._archive = archive
         self.workbook = workbook
         self.manifest = Manifest()
@@ -53,6 +76,7 @@ class ExcelWriter:
         self._drawings = []
         self._comments = []
         self._pivots = []
+        self._workbook_mime_type = workbook_mime_type
 
 
     def write_data(self):
@@ -98,7 +122,7 @@ class ExcelWriter:
 
         self._merge_vba()
 
-        self.manifest._write(archive, self.workbook)
+        self.manifest._write(archive, self.workbook, workbook_mime_type=self._workbook_mime_type)
 
     def _merge_vba(self):
         """
@@ -291,6 +315,6 @@ def save_workbook(workbook, filename):
     """
     archive = ZipFile(filename, 'w', ZIP_DEFLATED, allowZip64=True)
     workbook.properties.modified = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
-    writer = ExcelWriter(workbook, archive)
+    writer = ExcelWriter(workbook, archive, workbook_mime_type=_mime_type_from_filename(filename))
     writer.save()
     return True

--- a/fastpyxl/writer/tests/test_template.py
+++ b/fastpyxl/writer/tests/test_template.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2010-2024 fastpyxl
 
+import os
 from tempfile import NamedTemporaryFile
 from zipfile import ZipFile
 
 import pytest
 
+from fastpyxl import Workbook
 from fastpyxl.packaging.manifest import Manifest
 from fastpyxl.reader.excel import load_workbook
 from fastpyxl.xml.constants import ARC_CONTENT_TYPES, XLTM, XLTX, XLSM, XLSX
@@ -74,3 +76,14 @@ def test_save_xl_as_template(datadir, tmpl, keep_vba, wb_type):
     tmp = NamedTemporaryFile()
     wb.save(tmp)
     check_content_type(wb_type, tmp)
+
+
+@pytest.mark.parametrize('ext, wb_type', [
+    ('.xlsx', XLSX),
+    ('.xlsm', XLSM),
+])
+def test_new_workbook_content_type_matches_extension(tmp_path, ext, wb_type):
+    wb = Workbook()
+    fname = os.path.join(str(tmp_path), f"new{ext}")
+    wb.save(fname)
+    check_content_type(wb_type, fname)


### PR DESCRIPTION
## Summary
- Fixes #46: new `Workbook()` saved as `.xlsm` wrote the xlsx content type (`application/…sheet.main+xml`) into `[Content_Types].xml`, which Excel rejects as an invalid format.
- `workbook.mime_type` was derived only from `vba_archive`/`template` flags and had no knowledge of the output filename, so any extension/content-type mismatch slipped through.
- Thread an extension-derived mime type through `save_workbook` → `ExcelWriter` → `Manifest._write` so the workbook `Override` matches the output file's extension. Loaded workbooks and file-like targets (no filename) fall back to `workbook.mime_type` as before.

## Test plan
- [x] RED: added `test_new_workbook_content_type_matches_extension` — `.xlsm` case fails on master with exactly the reported symptom (`sheet.main+xml` instead of `sheet.macroEnabled.main+xml`); `.xlsx` passes.
- [x] GREEN: after the fix, full suite is 2767 passed, 9 skipped.
- [x] Verified end-to-end: generated `.xlsm` now contains `application/vnd.ms-excel.sheet.macroEnabled.main+xml` for the workbook part and opens cleanly in LibreOffice Calc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)