### PR TITLE
fix: suppress benign data validation extension warnings on load

### DIFF
--- a/fastpyxl/reader/tests/test_excel.py
+++ b/fastpyxl/reader/tests/test_excel.py
@@ -166,6 +166,55 @@ def test_file_closes(datadir, load_workbook):
     os.remove(filename)
 
 
+def test_empty_data_validation_extension_loads_without_warning(load_workbook, recwarn):
+    import io
+    import zipfile
+
+    sheet_xml = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData/>
+  <extLst>
+    <ext uri="{CCE6A557-97BC-4b89-ADB6-D9C93CAAB3DF}" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
+      <x14:dataValidations xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main"/>
+    </ext>
+  </extLst>
+</worksheet>"""
+
+    content_types = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"""
+
+    root_rels = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+
+    workbook = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"""
+
+    wb_rels = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"""
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("[Content_Types].xml", content_types)
+        z.writestr("_rels/.rels", root_rels)
+        z.writestr("xl/workbook.xml", workbook)
+        z.writestr("xl/_rels/workbook.xml.rels", wb_rels)
+        z.writestr("xl/worksheets/sheet1.xml", sheet_xml)
+
+    load_workbook(buf)
+    assert len(recwarn) == 0
+
+
 from ..excel import ExcelReader
 
 

--- a/fastpyxl/worksheet/_reader.py
+++ b/fastpyxl/worksheet/_reader.py
@@ -19,6 +19,8 @@ from fastpyxl.worksheet.dimensions import (
 from fastpyxl.xml.constants import (
     SHEET_MAIN_NS,
     EXT_TYPES,
+    X14_NS,
+    DATA_VALIDATION_EXT_URI,
 )
 from fastpyxl.formatting.formatting import ConditionalFormatting
 from fastpyxl.formula.translate import Translator
@@ -75,6 +77,29 @@ SCENARIOS_TAG = '{%s}scenarios' % SHEET_MAIN_NS
 DATA_TAG = '{%s}sheetData' % SHEET_MAIN_NS
 DIMENSION_TAG = '{%s}dimension' % SHEET_MAIN_NS
 CUSTOM_VIEWS_TAG = '{%s}customSheetViews' % SHEET_MAIN_NS
+X14_DATA_VALIDATION_TAG = '{%s}dataValidation' % X14_NS
+
+
+def _data_validation_extension_has_rules(ext_element):
+    """Return True when the x14 data validation extension contains rules."""
+    for child in ext_element:
+        if child.tag.endswith('}dataValidations'):
+            for rule in child:
+                if rule.tag == X14_DATA_VALIDATION_TAG:
+                    return True
+    return False
+
+
+def _data_validation_extension_is_benign(parser, ext_element):
+    """
+    Excel often writes an x14 data validation companion in extLst even when
+    the standard dataValidations block already holds the rules, or when the
+    extension container is empty. Neither case loses data we can read today.
+    """
+    if not _data_validation_extension_has_rules(ext_element):
+        return True
+    data_validations = getattr(parser, 'data_validations', None)
+    return data_validations is not None and len(data_validations) > 0
 
 
 def _cast_number(value):
@@ -353,8 +378,12 @@ class WorkSheetParser:
 
     def parse_extensions(self, element):
         extLst = ExtensionList.from_tree(element)
-        for e in extLst.ext:
-            ext_type = EXT_TYPES.get(e.uri.upper(), "Unknown")
+        for ext_element, extension in zip(element, extLst.ext):
+            uri = extension.uri.upper() if extension.uri else ""
+            if uri == DATA_VALIDATION_EXT_URI.upper():
+                if _data_validation_extension_is_benign(self, ext_element):
+                    continue
+            ext_type = EXT_TYPES.get(uri, "Unknown")
             msg = "{0} extension is not supported and will be removed".format(ext_type)
             warn(msg)
 

--- a/fastpyxl/worksheet/tests/test_reader.py
+++ b/fastpyxl/worksheet/tests/test_reader.py
@@ -540,6 +540,72 @@ class TestWorksheetParser:
         assert issubclass(w.category, UserWarning)
 
 
+    def test_empty_data_validation_extension_is_silent(self, WorkSheetParser, recwarn):
+        parser = WorkSheetParser
+
+        src = """
+        <extLst>
+            <ext uri="{CCE6A557-97BC-4b89-ADB6-D9C93CAAB3DF}" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
+                <x14:dataValidations xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main"/>
+            </ext>
+        </extLst>
+        """
+        element = fromstring(src)
+        parser.parse_extensions(element)
+        assert len(recwarn) == 0
+
+
+    def test_data_validation_extension_with_standard_block_is_silent(self, WorkSheetParser, recwarn):
+        parser = WorkSheetParser
+        from ..datavalidation import DataValidation, DataValidationList
+
+        parser.data_validations = DataValidationList(
+            dataValidation=[DataValidation(type="list", sqref="A1")]
+        )
+
+        src = """
+        <extLst>
+            <ext uri="{CCE6A557-97BC-4b89-ADB6-D9C93CAAB3DF}" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
+                <x14:dataValidations count="1" xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main">
+                    <x14:dataValidation type="list">
+                        <x14:formula1>
+                            <xm:f>Sheet2!$A$1:$A$5</xm:f>
+                        </x14:formula1>
+                        <xm:sqref>A1:A1048576</xm:sqref>
+                    </x14:dataValidation>
+                </x14:dataValidations>
+            </ext>
+        </extLst>
+        """
+        element = fromstring(src)
+        parser.parse_extensions(element)
+        assert len(recwarn) == 0
+
+
+    def test_x14_only_data_validation_extension_warns(self, WorkSheetParser, recwarn):
+        parser = WorkSheetParser
+
+        src = """
+        <extLst>
+            <ext uri="{CCE6A557-97BC-4b89-ADB6-D9C93CAAB3DF}" xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
+                <x14:dataValidations count="1" xmlns:xm="http://schemas.microsoft.com/office/excel/2006/main">
+                    <x14:dataValidation type="list">
+                        <x14:formula1>
+                            <xm:f>Sheet2!$A$1:$A$5</xm:f>
+                        </x14:formula1>
+                        <xm:sqref>A1:A1048576</xm:sqref>
+                    </x14:dataValidation>
+                </x14:dataValidations>
+            </ext>
+        </extLst>
+        """
+        element = fromstring(src)
+        parser.parse_extensions(element)
+        w = recwarn.pop()
+        assert issubclass(w.category, UserWarning)
+        assert "Data Validation" in str(w.message)
+
+
     def test_bad_conditional_format_rule(self, WorkSheetParser, recwarn):
         parser = WorkSheetParser
 

--- a/fastpyxl/xml/constants.py
+++ b/fastpyxl/xml/constants.py
@@ -66,6 +66,7 @@ CONTYPES_NS = PKG_NS + 'content-types'
 XSI_NS = 'http://www.w3.org/2001/XMLSchema-instance'
 XML_NS = 'http://www.w3.org/XML/1998/namespace'
 SHEET_MAIN_NS = 'http://schemas.openxmlformats.org/spreadsheetml/2006/main'
+X14_NS = 'http://schemas.microsoft.com/office/spreadsheetml/2009/9/main'
 
 # Drawing
 CHART_NS = "http://schemas.openxmlformats.org/drawingml/2006/chart"
@@ -111,9 +112,11 @@ XLSX = WORKBOOK % 'sheet'
 
 # Extensions to the specification
 
+DATA_VALIDATION_EXT_URI = '{CCE6A557-97BC-4B89-ADB6-D9C93CAAB3DF}'
+
 EXT_TYPES = {
     '{78C0D931-6437-407D-A8EE-F0AAD7539E65}': 'Conditional Formatting',
-    '{CCE6A557-97BC-4B89-ADB6-D9C93CAAB3DF}': 'Data Validation',
+    DATA_VALIDATION_EXT_URI: 'Data Validation',
     '{05C60535-1F16-4FD2-B633-F4F36F0B64E0}': 'Sparkline Group',
     '{A8765BA9-456A-4DAB-B4F3-ACF838C121DE}': 'Slicer List',
     '{FC87AEE6-9EDD-4A0A-B7FB-166176984837}': 'Protected Range',


### PR DESCRIPTION
## Summary
- Stops emitting `UserWarning` for the common Excel x14 Data Validation extension when it is empty or duplicates rules already loaded from the standard `<dataValidations>` block
- Keeps warnings when x14-only validation rules would be discarded (unsupported Office 2010+ validations with no standard-block fallback)
- Adds unit and integration tests covering empty extensions, redundant extensions, and x14-only data loss cases

Fixes #48

## Test plan
- [x] `uv run pytest fastpyxl/worksheet/tests/test_reader.py::TestWorksheetParser::test_empty_data_validation_extension_is_silent`
- [x] `uv run pytest fastpyxl/worksheet/tests/test_reader.py::TestWorksheetParser::test_data_validation_extension_with_standard_block_is_silent`
- [x] `uv run pytest fastpyxl/worksheet/tests/test_reader.py::TestWorksheetParser::test_x14_only_data_validation_extension_warns`
- [x] `uv run pytest fastpyxl/reader/tests/test_excel.py::test_empty_data_validation_extension_loads_without_warning`
- [x] `uv run pytest fastpyxl/worksheet/tests/test_reader.py fastpyxl/reader/tests/test_excel.py`