### PR TITLE
Fix docs publish trigger for master branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: CI Docs
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:
@@ -47,7 +47,7 @@ jobs:
     name: "Publish Docs"
     runs-on: ubuntu-latest
     needs: "build-docs"
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master'
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Summary
- The CI Docs workflow was configured for `main`, but this repo uses `master` as the default branch
- As a result, PR #52 merged successfully but **Publish Docs never ran** (no GitHub Pages deployments exist)
- Updates the push trigger and publish job condition to `master`

## Test plan
- [ ] Merge this PR and confirm `CI Docs / Publish Docs` runs on the merge commit
- [ ] Verify site is live at https://promptlytechnologies.com/fastpyxl/