### PR TITLE
Add openpyxl compatibility contract test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,26 @@ jobs:
 
       - name: Pytest
         run: uv run pytest
+
+  openpyxl-compat:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --all-groups
+
+      - name: openpyxl compatibility contract
+        run: uv run pytest fastpyxl/tests/compat -m openpyxl_compat

--- a/conftest.py
+++ b/conftest.py
@@ -47,4 +47,9 @@ def pytest_runtest_setup(item):
         elif item.get_closest_marker("no_pypy"):
             if platform.python_implementation() == "PyPy":
                 pytest.skip("Skipping pypy")
+        elif item.get_closest_marker("openpyxl_compat"):
+            try:
+                import openpyxl  # noqa: F401
+            except ImportError:
+                pytest.skip("openpyxl is required for compatibility contract tests")
 

--- a/fastpyxl/tests/compat/__init__.py
+++ b/fastpyxl/tests/compat/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2010-2024 fastpyxl
+
+"""openpyxl drop-in compatibility contract tests."""

--- a/fastpyxl/tests/compat/conftest.py
+++ b/fastpyxl/tests/compat/conftest.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2010-2024 fastpyxl
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fastpyxl():
+    import fastpyxl
+
+    return fastpyxl
+
+
+@pytest.fixture
+def openpyxl():
+    import openpyxl
+
+    return openpyxl
+
+
+@pytest.fixture
+def compat_tmp_path(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+READ_FIXTURES = (
+    Path("fastpyxl/reader/tests/data/sample.xlsx"),
+    Path("fastpyxl/reader/tests/data/empty_with_no_properties.xlsx"),
+    Path("fastpyxl/reader/tests/data/hidden_sheets.xlsx"),
+    Path("fastpyxl/tests/data/genuine/sample.xlsx"),
+    Path("fastpyxl/tests/data/genuine/empty.xlsx"),
+)

--- a/fastpyxl/tests/compat/conftest.py
+++ b/fastpyxl/tests/compat/conftest.py
@@ -26,10 +26,15 @@ def compat_tmp_path(tmp_path: Path) -> Path:
     return tmp_path
 
 
+_TESTS_DIR = Path(__file__).resolve().parents[1]
+_FASTPYXL_DIR = _TESTS_DIR.parent
+
 READ_FIXTURES = (
-    Path("fastpyxl/reader/tests/data/sample.xlsx"),
-    Path("fastpyxl/reader/tests/data/empty_with_no_properties.xlsx"),
-    Path("fastpyxl/reader/tests/data/hidden_sheets.xlsx"),
-    Path("fastpyxl/tests/data/genuine/sample.xlsx"),
-    Path("fastpyxl/tests/data/genuine/empty.xlsx"),
+    _FASTPYXL_DIR / "reader/tests/data/sample.xlsx",
+    _FASTPYXL_DIR / "reader/tests/data/empty_with_no_properties.xlsx",
+    _FASTPYXL_DIR / "reader/tests/data/hidden_sheets.xlsx",
+    _TESTS_DIR / "data/genuine/sample.xlsx",
+    _TESTS_DIR / "data/genuine/empty.xlsx",
 )
+
+GENUINE_SAMPLE_FIXTURE = _TESTS_DIR / "data/genuine/sample.xlsx"

--- a/fastpyxl/tests/compat/conftest.py
+++ b/fastpyxl/tests/compat/conftest.py
@@ -21,20 +21,41 @@ def openpyxl():
     return openpyxl
 
 
-@pytest.fixture
-def compat_tmp_path(tmp_path: Path) -> Path:
-    return tmp_path
-
-
 _TESTS_DIR = Path(__file__).resolve().parents[1]
 _FASTPYXL_DIR = _TESTS_DIR.parent
 
+
+def _fixture_id(path: Path) -> str:
+    for base, prefix in (
+        (_FASTPYXL_DIR / "reader/tests/data", "reader"),
+        (_TESTS_DIR / "data/genuine", "genuine"),
+    ):
+        try:
+            return f"{prefix}/{path.relative_to(base)}"
+        except ValueError:
+            continue
+    return path.name
+
+
 READ_FIXTURES = (
-    _FASTPYXL_DIR / "reader/tests/data/sample.xlsx",
-    _FASTPYXL_DIR / "reader/tests/data/empty_with_no_properties.xlsx",
-    _FASTPYXL_DIR / "reader/tests/data/hidden_sheets.xlsx",
-    _TESTS_DIR / "data/genuine/sample.xlsx",
-    _TESTS_DIR / "data/genuine/empty.xlsx",
+    (_fixture_id(_FASTPYXL_DIR / "reader/tests/data/sample.xlsx"), _FASTPYXL_DIR / "reader/tests/data/sample.xlsx"),
+    (
+        _fixture_id(_FASTPYXL_DIR / "reader/tests/data/empty_with_no_properties.xlsx"),
+        _FASTPYXL_DIR / "reader/tests/data/empty_with_no_properties.xlsx",
+    ),
+    (
+        _fixture_id(_FASTPYXL_DIR / "reader/tests/data/hidden_sheets.xlsx"),
+        _FASTPYXL_DIR / "reader/tests/data/hidden_sheets.xlsx",
+    ),
+    (_fixture_id(_TESTS_DIR / "data/genuine/sample.xlsx"), _TESTS_DIR / "data/genuine/sample.xlsx"),
+    (_fixture_id(_TESTS_DIR / "data/genuine/empty.xlsx"), _TESTS_DIR / "data/genuine/empty.xlsx"),
+    (
+        _fixture_id(_TESTS_DIR / "data/genuine/empty-with-styles.xlsx"),
+        _TESTS_DIR / "data/genuine/empty-with-styles.xlsx",
+    ),
 )
+
+READ_FIXTURE_IDS = tuple(fixture_id for fixture_id, _ in READ_FIXTURES)
+READ_FIXTURE_PATHS = tuple(fixture_path for _, fixture_path in READ_FIXTURES)
 
 GENUINE_SAMPLE_FIXTURE = _TESTS_DIR / "data/genuine/sample.xlsx"

--- a/fastpyxl/tests/compat/helpers.py
+++ b/fastpyxl/tests/compat/helpers.py
@@ -88,6 +88,11 @@ def assert_workbook_snapshots_equal(
                 f"{sheet_name}!{coordinate} data_type mismatch: "
                 f"fastpyxl={fast_cell.data_type!r} openpyxl={openpyxl_cell.data_type!r}"
             )
+            assert fast_cell.number_format == openpyxl_cell.number_format, (
+                f"{sheet_name}!{coordinate} number_format mismatch: "
+                f"fastpyxl={fast_cell.number_format!r} "
+                f"openpyxl={openpyxl_cell.number_format!r}"
+            )
 
 
 def assert_workbooks_match(fast_workbook: Any, openpyxl_workbook: Any) -> None:

--- a/fastpyxl/tests/compat/helpers.py
+++ b/fastpyxl/tests/compat/helpers.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2010-2024 fastpyxl
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+@dataclass(frozen=True)
+class CellSnapshot:
+    value: Any
+    data_type: str | None
+    number_format: str | None
+
+
+@dataclass(frozen=True)
+class SheetSnapshot:
+    title: str
+    max_row: int
+    max_column: int
+    cells: dict[str, CellSnapshot]
+
+
+@dataclass(frozen=True)
+class WorkbookSnapshot:
+    sheetnames: tuple[str, ...]
+    active_title: str
+    sheets: dict[str, SheetSnapshot]
+
+
+def _normalize_value(value: Any) -> Any:
+    if isinstance(value, datetime.datetime):
+        return value.replace(tzinfo=None)
+    if isinstance(value, datetime.time):
+        return value.replace(tzinfo=None)
+    return value
+
+
+def snapshot_workbook(workbook: Any) -> WorkbookSnapshot:
+    sheets: dict[str, SheetSnapshot] = {}
+    for name in workbook.sheetnames:
+        worksheet = workbook[name]
+        cells: dict[str, CellSnapshot] = {}
+        for row in worksheet.iter_rows():
+            for cell in row:
+                if cell.value is None:
+                    continue
+                cells[cell.coordinate] = CellSnapshot(
+                    value=_normalize_value(cell.value),
+                    data_type=getattr(cell, "data_type", None),
+                    number_format=getattr(cell, "number_format", None),
+                )
+        sheets[name] = SheetSnapshot(
+            title=worksheet.title,
+            max_row=worksheet.max_row,
+            max_column=worksheet.max_column,
+            cells=cells,
+        )
+    return WorkbookSnapshot(
+        sheetnames=tuple(workbook.sheetnames),
+        active_title=workbook.active.title,
+        sheets=sheets,
+    )
+
+
+def assert_workbook_snapshots_equal(
+    fast_snapshot: WorkbookSnapshot,
+    openpyxl_snapshot: WorkbookSnapshot,
+) -> None:
+    assert fast_snapshot.sheetnames == openpyxl_snapshot.sheetnames
+    assert fast_snapshot.active_title == openpyxl_snapshot.active_title
+    assert set(fast_snapshot.sheets) == set(openpyxl_snapshot.sheets)
+    for sheet_name in fast_snapshot.sheetnames:
+        fast_sheet = fast_snapshot.sheets[sheet_name]
+        openpyxl_sheet = openpyxl_snapshot.sheets[sheet_name]
+        assert fast_sheet.title == openpyxl_sheet.title
+        assert fast_sheet.max_row == openpyxl_sheet.max_row
+        assert fast_sheet.max_column == openpyxl_sheet.max_column
+        assert set(fast_sheet.cells) == set(openpyxl_sheet.cells)
+        for coordinate, fast_cell in fast_sheet.cells.items():
+            openpyxl_cell = openpyxl_sheet.cells[coordinate]
+            assert fast_cell.value == openpyxl_cell.value, (
+                f"{sheet_name}!{coordinate} value mismatch: "
+                f"fastpyxl={fast_cell.value!r} openpyxl={openpyxl_cell.value!r}"
+            )
+            assert fast_cell.data_type == openpyxl_cell.data_type, (
+                f"{sheet_name}!{coordinate} data_type mismatch: "
+                f"fastpyxl={fast_cell.data_type!r} openpyxl={openpyxl_cell.data_type!r}"
+            )
+
+
+def assert_workbooks_match(fast_workbook: Any, openpyxl_workbook: Any) -> None:
+    assert_workbook_snapshots_equal(
+        snapshot_workbook(fast_workbook),
+        snapshot_workbook(openpyxl_workbook),
+    )
+
+
+def load_fixture_both(path: Path, **kwargs: Any) -> tuple[Any, Any]:
+    import fastpyxl
+    import openpyxl
+
+    return (
+        fastpyxl.load_workbook(path, **kwargs),
+        openpyxl.load_workbook(path, **kwargs),
+    )
+
+
+def save_and_reload_cross(
+    writer_workbook: Any,
+    reader_load: Any,
+    path: Path,
+) -> Any:
+    writer_workbook.save(path)
+    return reader_load(path)

--- a/fastpyxl/tests/compat/test_api_surface.py
+++ b/fastpyxl/tests/compat/test_api_surface.py
@@ -2,26 +2,13 @@
 
 from __future__ import annotations
 
+import importlib
 import inspect
 
 import pytest
 
 
 pytestmark = pytest.mark.openpyxl_compat
-
-
-PUBLIC_TOP_LEVEL_SYMBOLS = (
-    "Workbook",
-    "load_workbook",
-    "open",
-    "DEFUSEDXML",
-    "LXML",
-    "NUMPY",
-    "__version__",
-    "__author__",
-    "__license__",
-    "__url__",
-)
 
 
 PUBLIC_SUBMODULES = (
@@ -39,17 +26,37 @@ PUBLIC_SUBMODULES = (
     "writer",
 )
 
+# openpyxl symbols fastpyxl intentionally does not expose at the top level.
+OPENPYXL_TOP_LEVEL_ALLOWLIST = frozenset({"DEBUG", "descriptors"})
 
-def test_public_top_level_symbols_exist(fastpyxl, openpyxl):
-    for name in PUBLIC_TOP_LEVEL_SYMBOLS:
-        assert hasattr(fastpyxl, name), f"fastpyxl missing public symbol {name!r}"
-        assert hasattr(openpyxl, name), f"openpyxl missing public symbol {name!r}"
+# Per-submodule openpyxl symbols fastpyxl intentionally does not expose.
+OPENPYXL_SUBMODULE_ALLOWLIST: dict[str, frozenset[str]] = {
+    "utils": frozenset({"bound_dictionary"}),
+}
 
 
-def test_public_submodules_exist(fastpyxl, openpyxl):
-    for name in PUBLIC_SUBMODULES:
-        assert hasattr(fastpyxl, name), f"fastpyxl missing submodule {name!r}"
-        assert hasattr(openpyxl, name), f"openpyxl missing submodule {name!r}"
+def _public_names(module: object) -> set[str]:
+    return {name for name in dir(module) if not name.startswith("_")}
+
+
+def test_openpyxl_top_level_exports_available_in_fastpyxl(fastpyxl, openpyxl):
+    missing = _public_names(openpyxl) - _public_names(fastpyxl) - OPENPYXL_TOP_LEVEL_ALLOWLIST
+    assert not missing, f"fastpyxl missing openpyxl top-level exports: {sorted(missing)}"
+
+
+@pytest.mark.parametrize("submodule", PUBLIC_SUBMODULES)
+def test_openpyxl_submodule_exports_available_in_fastpyxl(
+    submodule: str,
+    fastpyxl,
+    openpyxl,
+):
+    fast_module = importlib.import_module(f"{fastpyxl.__name__}.{submodule}")
+    openpyxl_module = importlib.import_module(f"{openpyxl.__name__}.{submodule}")
+    allowlist = OPENPYXL_SUBMODULE_ALLOWLIST.get(submodule, frozenset())
+    missing = _public_names(openpyxl_module) - _public_names(fast_module) - allowlist
+    assert not missing, (
+        f"fastpyxl.{submodule} missing openpyxl.{submodule} exports: {sorted(missing)}"
+    )
 
 
 def test_load_workbook_signature_matches(fastpyxl, openpyxl):
@@ -66,14 +73,7 @@ def test_workbook_constructor_signature_matches(fastpyxl, openpyxl):
     fast_sig = inspect.signature(fastpyxl.Workbook)
     openpyxl_sig = inspect.signature(openpyxl.Workbook)
     assert list(fast_sig.parameters) == list(openpyxl_sig.parameters)
-
-
-def test_workbook_module_exports_match(fastpyxl, openpyxl):
-    assert hasattr(fastpyxl.workbook, "Workbook")
-    assert hasattr(openpyxl.workbook, "Workbook")
-
-
-def test_styles_module_exports_match(fastpyxl, openpyxl):
-    for name in ("Font", "PatternFill", "Alignment", "Border", "Side", "Protection"):
-        assert hasattr(fastpyxl.styles, name), name
-        assert hasattr(openpyxl.styles, name), name
+    for name, fast_param in fast_sig.parameters.items():
+        openpyxl_param = openpyxl_sig.parameters[name]
+        assert fast_param.default == openpyxl_param.default, name
+        assert fast_param.kind == openpyxl_param.kind, name

--- a/fastpyxl/tests/compat/test_api_surface.py
+++ b/fastpyxl/tests/compat/test_api_surface.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2010-2024 fastpyxl
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+pytestmark = pytest.mark.openpyxl_compat
+
+
+PUBLIC_TOP_LEVEL_SYMBOLS = (
+    "Workbook",
+    "load_workbook",
+    "open",
+    "DEFUSEDXML",
+    "LXML",
+    "NUMPY",
+    "__version__",
+    "__author__",
+    "__license__",
+    "__url__",
+)
+
+
+PUBLIC_SUBMODULES = (
+    "cell",
+    "chart",
+    "chartsheet",
+    "comments",
+    "drawing",
+    "formatting",
+    "formula",
+    "styles",
+    "utils",
+    "workbook",
+    "worksheet",
+    "writer",
+)
+
+
+def test_public_top_level_symbols_exist(fastpyxl, openpyxl):
+    for name in PUBLIC_TOP_LEVEL_SYMBOLS:
+        assert hasattr(fastpyxl, name), f"fastpyxl missing public symbol {name!r}"
+        assert hasattr(openpyxl, name), f"openpyxl missing public symbol {name!r}"
+
+
+def test_public_submodules_exist(fastpyxl, openpyxl):
+    for name in PUBLIC_SUBMODULES:
+        assert hasattr(fastpyxl, name), f"fastpyxl missing submodule {name!r}"
+        assert hasattr(openpyxl, name), f"openpyxl missing submodule {name!r}"
+
+
+def test_load_workbook_signature_matches(fastpyxl, openpyxl):
+    fast_sig = inspect.signature(fastpyxl.load_workbook)
+    openpyxl_sig = inspect.signature(openpyxl.load_workbook)
+    assert list(fast_sig.parameters) == list(openpyxl_sig.parameters)
+    for name, fast_param in fast_sig.parameters.items():
+        openpyxl_param = openpyxl_sig.parameters[name]
+        assert fast_param.default == openpyxl_param.default, name
+        assert fast_param.kind == openpyxl_param.kind, name
+
+
+def test_workbook_constructor_signature_matches(fastpyxl, openpyxl):
+    fast_sig = inspect.signature(fastpyxl.Workbook)
+    openpyxl_sig = inspect.signature(openpyxl.Workbook)
+    assert list(fast_sig.parameters) == list(openpyxl_sig.parameters)
+
+
+def test_workbook_module_exports_match(fastpyxl, openpyxl):
+    assert hasattr(fastpyxl.workbook, "Workbook")
+    assert hasattr(openpyxl.workbook, "Workbook")
+
+
+def test_styles_module_exports_match(fastpyxl, openpyxl):
+    for name in ("Font", "PatternFill", "Alignment", "Border", "Side", "Protection"):
+        assert hasattr(fastpyxl.styles, name), name
+        assert hasattr(openpyxl.styles, name), name

--- a/fastpyxl/tests/compat/test_behavioral_parity.py
+++ b/fastpyxl/tests/compat/test_behavioral_parity.py
@@ -58,7 +58,7 @@ def test_sheet_management_matches(fastpyxl, openpyxl):
     assert fast_wb.sheetnames == openpyxl_wb.sheetnames
 
 
-def test_fastpyxl_save_openpyxl_read(compat_tmp_path, fastpyxl, openpyxl):
+def test_fastpyxl_save_openpyxl_read(tmp_path: Path, fastpyxl, openpyxl):
     wb = fastpyxl.Workbook()
     ws = wb.active
     ws.title = "Export"
@@ -66,13 +66,13 @@ def test_fastpyxl_save_openpyxl_read(compat_tmp_path, fastpyxl, openpyxl):
     ws.append(["widgets", 12])
     ws["C2"] = "=B2*2"
 
-    path = compat_tmp_path / "fastpyxl_written.xlsx"
+    path = tmp_path / "fastpyxl_written.xlsx"
     reloaded = save_and_reload_cross(wb, openpyxl.load_workbook, path)
     reference = fastpyxl.load_workbook(path)
     assert_workbooks_match(reference, reloaded)
 
 
-def test_openpyxl_save_fastpyxl_read(compat_tmp_path, fastpyxl, openpyxl):
+def test_openpyxl_save_fastpyxl_read(tmp_path: Path, fastpyxl, openpyxl):
     wb = openpyxl.Workbook()
     ws = wb.active
     ws.title = "Import"
@@ -80,25 +80,25 @@ def test_openpyxl_save_fastpyxl_read(compat_tmp_path, fastpyxl, openpyxl):
     ws.append(["gadgets", 7])
     ws["C2"] = "=B2+1"
 
-    path = compat_tmp_path / "openpyxl_written.xlsx"
+    path = tmp_path / "openpyxl_written.xlsx"
     reloaded = save_and_reload_cross(wb, fastpyxl.load_workbook, path)
     reference = openpyxl.load_workbook(path)
     assert_workbooks_match(reloaded, reference)
 
 
-@pytest.mark.parametrize(
-    "extension",
-    ["xlsx", "xlsm", "xltx", "xltm"],
-)
+@pytest.mark.parametrize("extension", ["xlsx", "xlsm", "xltx", "xltm"])
+@pytest.mark.parametrize("writer", ["fastpyxl", "openpyxl"])
 def test_save_extension_round_trip(
     extension: str,
-    compat_tmp_path,
+    writer: str,
+    tmp_path: Path,
     fastpyxl,
     openpyxl,
 ):
-    wb = fastpyxl.Workbook()
-    wb.active["A1"] = f"saved-as-{extension}"
-    path = compat_tmp_path / f"workbook.{extension}"
+    writer_lib = fastpyxl if writer == "fastpyxl" else openpyxl
+    wb = writer_lib.Workbook()
+    wb.active["A1"] = f"saved-as-{extension}-by-{writer}"
+    path = tmp_path / f"workbook-{writer}.{extension}"
 
     wb.save(path)
     fast_reloaded = fastpyxl.load_workbook(path)

--- a/fastpyxl/tests/compat/test_behavioral_parity.py
+++ b/fastpyxl/tests/compat/test_behavioral_parity.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from .conftest import GENUINE_SAMPLE_FIXTURE
 from .helpers import assert_workbooks_match, save_and_reload_cross
 
 
@@ -106,7 +107,7 @@ def test_save_extension_round_trip(
 
 
 def test_read_only_iteration_values_match(fastpyxl, openpyxl):
-    fixture = Path("fastpyxl/tests/data/genuine/sample.xlsx")
+    fixture = GENUINE_SAMPLE_FIXTURE
     fast_wb = fastpyxl.load_workbook(fixture, read_only=True)
     openpyxl_wb = openpyxl.load_workbook(fixture, read_only=True)
     try:

--- a/fastpyxl/tests/compat/test_behavioral_parity.py
+++ b/fastpyxl/tests/compat/test_behavioral_parity.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2010-2024 fastpyxl
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+import pytest
+
+from .helpers import assert_workbooks_match, save_and_reload_cross
+
+
+pytestmark = pytest.mark.openpyxl_compat
+
+
+def test_empty_workbook_defaults_match(fastpyxl, openpyxl):
+    fast_wb = fastpyxl.Workbook()
+    openpyxl_wb = openpyxl.Workbook()
+    assert_workbooks_match(fast_wb, openpyxl_wb)
+
+
+def test_append_rows_and_cell_values_match(fastpyxl, openpyxl):
+    fast_wb = fastpyxl.Workbook()
+    openpyxl_wb = openpyxl.Workbook()
+    for wb in (fast_wb, openpyxl_wb):
+        ws = wb.active
+        ws.title = "Data"
+        ws["A1"] = 42
+        ws["B1"] = "hello"
+        ws.append([1, 2, 3])
+        ws["A3"] = datetime.datetime(2024, 1, 15, 10, 30)
+    assert_workbooks_match(fast_wb, openpyxl_wb)
+
+
+def test_formula_assignment_matches(fastpyxl, openpyxl):
+    fast_wb = fastpyxl.Workbook()
+    openpyxl_wb = openpyxl.Workbook()
+    for wb in (fast_wb, openpyxl_wb):
+        ws = wb.active
+        ws["A1"] = 10
+        ws["A2"] = 20
+        ws["A3"] = "=A1+A2"
+        ws["A4"] = "=SUM(A1:A3)"
+    assert_workbooks_match(fast_wb, openpyxl_wb)
+
+
+def test_sheet_management_matches(fastpyxl, openpyxl):
+    fast_wb = fastpyxl.Workbook()
+    openpyxl_wb = openpyxl.Workbook()
+    for wb in (fast_wb, openpyxl_wb):
+        wb.active.title = "First"
+        second = wb.create_sheet("Second", 1)
+        second["A1"] = "moved"
+        wb.create_sheet("Third")
+        wb.move_sheet("Third", offset=-1)
+    assert_workbooks_match(fast_wb, openpyxl_wb)
+    assert fast_wb.sheetnames == openpyxl_wb.sheetnames
+
+
+def test_fastpyxl_save_openpyxl_read(compat_tmp_path, fastpyxl, openpyxl):
+    wb = fastpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Export"
+    ws.append(["name", "count"])
+    ws.append(["widgets", 12])
+    ws["C2"] = "=B2*2"
+
+    path = compat_tmp_path / "fastpyxl_written.xlsx"
+    reloaded = save_and_reload_cross(wb, openpyxl.load_workbook, path)
+    reference = fastpyxl.load_workbook(path)
+    assert_workbooks_match(reference, reloaded)
+
+
+def test_openpyxl_save_fastpyxl_read(compat_tmp_path, fastpyxl, openpyxl):
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Import"
+    ws.append(["name", "count"])
+    ws.append(["gadgets", 7])
+    ws["C2"] = "=B2+1"
+
+    path = compat_tmp_path / "openpyxl_written.xlsx"
+    reloaded = save_and_reload_cross(wb, fastpyxl.load_workbook, path)
+    reference = openpyxl.load_workbook(path)
+    assert_workbooks_match(reloaded, reference)
+
+
+@pytest.mark.parametrize(
+    "extension",
+    ["xlsx", "xlsm", "xltx", "xltm"],
+)
+def test_save_extension_round_trip(
+    extension: str,
+    compat_tmp_path,
+    fastpyxl,
+    openpyxl,
+):
+    wb = fastpyxl.Workbook()
+    wb.active["A1"] = f"saved-as-{extension}"
+    path = compat_tmp_path / f"workbook.{extension}"
+
+    wb.save(path)
+    fast_reloaded = fastpyxl.load_workbook(path)
+    openpyxl_reloaded = openpyxl.load_workbook(path)
+    assert_workbooks_match(fast_reloaded, openpyxl_reloaded)
+
+
+def test_read_only_iteration_values_match(fastpyxl, openpyxl):
+    fixture = Path("fastpyxl/tests/data/genuine/sample.xlsx")
+    fast_wb = fastpyxl.load_workbook(fixture, read_only=True)
+    openpyxl_wb = openpyxl.load_workbook(fixture, read_only=True)
+    try:
+        assert_workbooks_match(fast_wb, openpyxl_wb)
+    finally:
+        fast_wb.close()
+        openpyxl_wb.close()

--- a/fastpyxl/tests/compat/test_round_trip.py
+++ b/fastpyxl/tests/compat/test_round_trip.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2010-2024 fastpyxl
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .conftest import READ_FIXTURES
+from .helpers import assert_workbooks_match, load_fixture_both
+
+
+pytestmark = pytest.mark.openpyxl_compat
+
+
+@pytest.mark.parametrize("fixture_path", READ_FIXTURES, ids=lambda p: p.name)
+def test_both_libraries_read_fixture_equivalently(fixture_path: Path):
+    fast_wb, openpyxl_wb = load_fixture_both(fixture_path)
+    try:
+        assert_workbooks_match(fast_wb, openpyxl_wb)
+    finally:
+        if hasattr(fast_wb, "close"):
+            fast_wb.close()
+        if hasattr(openpyxl_wb, "close"):
+            openpyxl_wb.close()
+
+
+@pytest.mark.parametrize("fixture_path", READ_FIXTURES, ids=lambda p: p.name)
+def test_fastpyxl_save_fixture_openpyxl_can_read(
+    fixture_path: Path,
+    compat_tmp_path,
+    fastpyxl,
+    openpyxl,
+):
+    fast_wb, _ = load_fixture_both(fixture_path)
+    try:
+        out = compat_tmp_path / f"resaved-{fixture_path.name}"
+        fast_wb.save(out)
+        openpyxl_reloaded = openpyxl.load_workbook(out)
+        fast_reloaded = fastpyxl.load_workbook(out)
+        assert_workbooks_match(fast_reloaded, openpyxl_reloaded)
+    finally:
+        if hasattr(fast_wb, "close"):
+            fast_wb.close()
+
+
+@pytest.mark.parametrize("fixture_path", READ_FIXTURES, ids=lambda p: p.name)
+def test_openpyxl_save_fixture_fastpyxl_can_read(
+    fixture_path: Path,
+    compat_tmp_path,
+    fastpyxl,
+    openpyxl,
+):
+    _, openpyxl_wb = load_fixture_both(fixture_path)
+    try:
+        out = compat_tmp_path / f"resaved-{fixture_path.name}"
+        openpyxl_wb.save(out)
+        fast_reloaded = fastpyxl.load_workbook(out)
+        openpyxl_reloaded = openpyxl.load_workbook(out)
+        assert_workbooks_match(fast_reloaded, openpyxl_reloaded)
+    finally:
+        if hasattr(openpyxl_wb, "close"):
+            openpyxl_wb.close()

--- a/fastpyxl/tests/compat/test_round_trip.py
+++ b/fastpyxl/tests/compat/test_round_trip.py
@@ -6,14 +6,14 @@ from pathlib import Path
 
 import pytest
 
-from .conftest import READ_FIXTURES
+from .conftest import READ_FIXTURE_IDS, READ_FIXTURE_PATHS
 from .helpers import assert_workbooks_match, load_fixture_both
 
 
 pytestmark = pytest.mark.openpyxl_compat
 
 
-@pytest.mark.parametrize("fixture_path", READ_FIXTURES, ids=lambda p: p.name)
+@pytest.mark.parametrize("fixture_path", READ_FIXTURE_PATHS, ids=READ_FIXTURE_IDS)
 def test_both_libraries_read_fixture_equivalently(fixture_path: Path):
     fast_wb, openpyxl_wb = load_fixture_both(fixture_path)
     try:
@@ -25,16 +25,16 @@ def test_both_libraries_read_fixture_equivalently(fixture_path: Path):
             openpyxl_wb.close()
 
 
-@pytest.mark.parametrize("fixture_path", READ_FIXTURES, ids=lambda p: p.name)
+@pytest.mark.parametrize("fixture_path", READ_FIXTURE_PATHS, ids=READ_FIXTURE_IDS)
 def test_fastpyxl_save_fixture_openpyxl_can_read(
     fixture_path: Path,
-    compat_tmp_path,
+    tmp_path: Path,
     fastpyxl,
     openpyxl,
 ):
     fast_wb, _ = load_fixture_both(fixture_path)
     try:
-        out = compat_tmp_path / f"resaved-{fixture_path.name}"
+        out = tmp_path / f"resaved-{fixture_path.name}"
         fast_wb.save(out)
         openpyxl_reloaded = openpyxl.load_workbook(out)
         fast_reloaded = fastpyxl.load_workbook(out)
@@ -44,16 +44,16 @@ def test_fastpyxl_save_fixture_openpyxl_can_read(
             fast_wb.close()
 
 
-@pytest.mark.parametrize("fixture_path", READ_FIXTURES, ids=lambda p: p.name)
+@pytest.mark.parametrize("fixture_path", READ_FIXTURE_PATHS, ids=READ_FIXTURE_IDS)
 def test_openpyxl_save_fixture_fastpyxl_can_read(
     fixture_path: Path,
-    compat_tmp_path,
+    tmp_path: Path,
     fastpyxl,
     openpyxl,
 ):
     _, openpyxl_wb = load_fixture_both(fixture_path)
     try:
-        out = compat_tmp_path / f"resaved-{fixture_path.name}"
+        out = tmp_path / f"resaved-{fixture_path.name}"
         openpyxl_wb.save(out)
         fast_reloaded = fastpyxl.load_workbook(out)
         openpyxl_reloaded = openpyxl.load_workbook(out)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "ruff>=0.15.7",
     "ty>=0.0.24",
     "pytest-cov>=5.0.0",
+    "openpyxl==3.1.5",
 ]
 docs = [
     "lxml",
@@ -99,6 +100,7 @@ markers = [
     "pandas_required: Pandas required for the test",
     "numpy_required: Numpy required for the test",
     "no_pypy: do not run on pypy",
+    "openpyxl_compat: openpyxl required for drop-in compatibility contract tests",
 ]
 filterwarnings = [
     "error",

--- a/uv.lock
+++ b/uv.lock
@@ -568,6 +568,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "lxml" },
+    { name = "openpyxl" },
     { name = "pandas" },
     { name = "pillow" },
     { name = "pytest" },
@@ -591,6 +592,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "lxml" },
+    { name = "openpyxl", specifier = "==3.1.5" },
     { name = "pandas" },
     { name = "pillow" },
     { name = "pytest" },
@@ -1579,6 +1581,18 @@ wheels = [
 ]
 
 [[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
 name = "overrides"
 version = "7.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1680,7 +1694,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an automated **openpyxl drop-in compatibility contract** to enforce fastpyxl's core promise: change the import, nothing else.

The suite compares fastpyxl against **openpyxl 3.1.5** (the version used in README benchmarks) across three tiers:

1. **API surface** — public symbols, `load_workbook` signature, key submodule exports
2. **Behavioral parity** — workbook creation, append, formulas, sheet management, cross-library save/load, extension round-trips (`.xlsx`/`.xlsm`/`.xltx`/`.xltm`), read-only iteration
3. **Fixture round-trips** — both libraries read the same files equivalently; each library can re-save and be read by the other

## Changes

- Add `openpyxl==3.1.5` to dev dependencies
- Add `@pytest.mark.openpyxl_compat` marker with skip-if-not-installed behavior
- New `fastpyxl/tests/compat/` package with snapshot-based workbook comparison helpers
- New CI job `openpyxl-compat` (Python 3.12) that runs `pytest fastpyxl/tests/compat -m openpyxl_compat`

## Test plan

- [x] `uv run pytest fastpyxl/tests/compat -m openpyxl_compat` — 32 passed
- [x] `uv run ty check` — passed
- [ ] CI `openpyxl-compat` job passes on PR

## Follow-ups (not in this PR)

- Benchmark regression gate in CI (`scripts/benchmark.py hotpath`)
- Document any intentional divergences as `xfail` entries as they are discovered
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8087ae5a-0730-42b6-b20c-90b12cf50f49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8087ae5a-0730-42b6-b20c-90b12cf50f49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

